### PR TITLE
Add Cinnamon 1_shell community theme

### DIFF
--- a/public/configs/community/cinnamon-1_shell.json
+++ b/public/configs/community/cinnamon-1_shell.json
@@ -1,0 +1,127 @@
+{
+  "id": "cinnamon-1_shell",
+  "name": "Cinnamon 1_shell",
+  "description": "Kayla Cinnamon's mod of the original 1_shell theme including the WinGet and GitHub Copilot segments. Already includes Git integration",
+  "icon": "Code2",
+  "author": "Kayla Cinnamon",
+  "tags": ["developer", "copilot", "winget", "git"],
+  "config": {
+    "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
+    "blocks": [
+      {
+        "alignment": "left",
+        "newline": true,
+        "segments": [
+          {
+            "foreground": "#ffbebc",
+            "leading_diamond": "<#ff70a6> \ue200 </>",
+            "properties": {
+              "display_host": true
+            },
+            "style": "diamond",
+            "template": "{{ .UserName }} <#ffffff>on</>",
+            "type": "session"
+          },
+          {
+            "foreground": "#bc93ff",
+            "properties": {
+              "time_format": "Monday <#ffffff>at</> 3:04 PM"
+            },
+            "style": "diamond",
+            "template": " {{ .CurrentDate | date .Format }} ",
+            "type": "time"
+          },
+          {
+            "type": "winget",
+            "style": "plain",
+            "foreground": "#70e2ff",
+            "properties": {
+              "cache_duration": "5m"
+            }
+          },
+          {
+            "foreground": "#ee79d1",
+            "properties": {
+              "branch_icon": " \ue725 ",
+              "fetch_status": true,
+              "fetch_upstream_icon": true,
+              "fetch_worktree_count": true
+            },
+            "style": "diamond",
+            "template": " {{ .UpstreamIcon }}{{ .HEAD }}{{if .BranchStatus }} {{ .BranchStatus }}{{ end }}{{ if .Working.Changed }} \uf044 {{ .Working.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Staging.Changed }} \uf046 {{ .Staging.String }}{{ end }}{{ if gt .StashCount 0 }} \ueb4b {{ .StashCount }}{{ end }} ",
+            "type": "git"
+          }
+        ],
+        "type": "prompt"
+      },
+      {
+        "alignment": "right",
+        "segments": [
+          {
+            "foreground": "#a9ffb4",
+            "style": "plain",
+            "type": "text"
+          },
+          {
+            "properties": {
+              "root_icon": "\uf292 "
+            },
+            "style": "diamond",
+            "template": " \uf0e7 ",
+            "type": "root"
+          },
+          {
+            "type": "copilot",
+            "template": "   {{ .Premium.Percent.Gauge }} ",
+            "cache": {
+              "duration": "5m",
+              "strategy": "session"
+            },
+            "properties": {
+              "http_timeout": 1000
+            }
+          }
+        ],
+        "type": "prompt"
+      },
+      {
+        "alignment": "left",
+        "newline": true,
+        "segments": [
+          {
+            "foreground": "#ffafd2",
+            "leading_diamond": "<#00c7fc> \ue285 </><#ffafd2>{</>",
+            "properties": {
+              "folder_icon": "\uf07b",
+              "folder_separator_icon": " \uebcb ",
+              "home_icon": "home",
+              "style": "agnoster_full"
+            },
+            "style": "diamond",
+            "template": " \ue5ff {{ .Path }} ",
+            "trailing_diamond": "<#ffafd2>}</>",
+            "type": "path"
+          },
+          {
+            "foreground": "#A9FFB4",
+            "foreground_templates": ["{{ if gt .Code 0 }}#ef5350{{ end }}"],
+            "properties": {
+              "always_enabled": true
+            },
+            "style": "plain",
+            "template": " \ueb05 ",
+            "type": "status"
+          }
+        ],
+        "type": "prompt"
+      }
+    ],
+    "console_title_template": "{{ .Folder }}",
+    "transient_prompt": {
+      "background": "transparent",
+      "foreground": "#FEF5ED",
+      "template": "\ue285 "
+    },
+    "version": 3
+  }
+}

--- a/public/configs/community/manifest.json
+++ b/public/configs/community/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "lastUpdated": "2025-12-29",
+  "lastUpdated": "2025-12-30",
   "configs": [
     {
       "id": "dotnet-azure-developer",
@@ -10,6 +10,15 @@
       "author": "James Montemagno",
       "tags": ["dotnet", "azure", "cloud", "developer", "csharp"],
       "file": "dotnet-azure-developer.json"
+    },
+    {
+      "id": "cinnamon-1_shell",
+      "name": "Cinnamon 1_shell",
+      "description": "Kayla Cinnamon's mod of the original 1_shell theme including the WinGet and GitHub Copilot segments. Already includes Git integration",
+      "icon": "Code2",
+      "author": "Kayla Cinnamon",
+      "tags": ["developer", "copilot", "winget", "git"],
+      "file": "cinnamon-1_shell.json"
     }
   ]
 }


### PR DESCRIPTION
## Summary

This PR adds a new community theme contribution: **Cinnamon 1_shell**
<img width="271" height="54" alt="image" src="https://github.com/user-attachments/assets/c7839ba1-d684-454d-aeca-0d590218f18c" />


## Configuration Details

- **Name**: Cinnamon 1_shell
- **Author**: Kayla Cinnamon
- **Description**: Kayla Cinnamon's mod of the original 1_shell theme including the WinGet and GitHub Copilot segments. Already includes Git integration.

## Features

- 🎨 Beautiful color scheme with pastel tones
- ⏰ Time display with day of week
- 📦 WinGet segment for package updates
- 🤖 GitHub Copilot status segment
- 🔀 Git integration with branch status, working changes, and stash count
- 📁 Full path display with custom folder icons
- ✨ Transient prompt for cleaner terminal history

## Tags

`developer`, `copilot`, `winget`, `git`

## Checklist

- [x] Configuration file follows the required structure
- [x] Updated `manifest.json` with new configuration entry
- [x] Ran `npm run validate` - all validations passed ✅
- [x] Followed contribution guidelines