### PR TITLE
Bugfix:  changed ufd03 to uebd8 for Azure Nerd Icon per Oh-My-Posh discussion

### DIFF
--- a/public/configs/community/dotnet-azure-developer.json
+++ b/public/configs/community/dotnet-azure-developer.json
@@ -80,7 +80,7 @@
           "powerline_symbol": "\ue0b0",
           "foreground": "p:text-light",
           "background": "p:azure-bg",
-          "template": " \ufd03 {{ .EnvironmentName }} "
+          "template": " \uebd8 {{ .EnvironmentName }} "
         },
         {
           "type": "docker",

--- a/public/segments/cloud.json
+++ b/public/segments/cloud.json
@@ -38,7 +38,7 @@
     "name": "Azure",
     "description": "Displays the current Azure CLI subscription name and ID",
     "icon": "cloud-azure",
-    "defaultTemplate": " \ufd03 {{ .Name }} ",
+    "defaultTemplate": " \uebd8 {{ .Name }} ",
     "defaultForeground": "#ffffff",
     "defaultBackground": "#0078D4",
     "previewText": "My Subscription",


### PR DESCRIPTION
This is a bugfix for the current Azure Glyph that's in the configuration tool - per:  https://github.com/JanDeDobbeleer/oh-my-posh/discussions/4095 - the current glyph referenced (ufd03) isn't within distributed nerdfonts and is discussed within this OMP discussion.  https://github.com/JanDeDobbeleer/oh-my-posh/discussions/4095

---

**By submitting this PR, I confirm that my contribution is made under the terms of the MIT License.**
