### PR TITLE
fix: delete private field instead of setting false for npm publish

### DIFF
--- a/.github/workflows/publish-mcp-npm.yml
+++ b/.github/workflows/publish-mcp-npm.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Set publishable package metadata
         run: |
-          npm pkg set private=false
+          npm pkg delete private
           npm version "${{ steps.version.outputs.version }}" --no-git-tag-version --allow-same-version
 
       - name: Build MCP package


### PR DESCRIPTION
The `npm pkg set private=false` command sets the field to the string `"false"`, which npm still treats as truthy/private. Changed to `npm pkg delete private` to remove the field entirely, which allows publishing.