### PR TITLE
fix(preview): honor path segment style options in preview

### DIFF
--- a/src/components/PreviewPanel/__tests__/pathPreview.test.ts
+++ b/src/components/PreviewPanel/__tests__/pathPreview.test.ts
@@ -3,10 +3,11 @@ import { formatPathPreview } from '../pathPreview';
 import { getPreviewText } from '../templateUtils';
 import type { Segment } from '../../../types/ohmyposh';
 
+// Mock path is ~/projects/src/my-app (root ~, intermediates projects + src, current my-app)
 describe('formatPathPreview', () => {
   it('returns the full mock path when no options are set', () => {
-    expect(formatPathPreview()).toBe('~/dev/my-app');
-    expect(formatPathPreview({})).toBe('~/dev/my-app');
+    expect(formatPathPreview()).toBe('~/projects/src/my-app');
+    expect(formatPathPreview({})).toBe('~/projects/src/my-app');
   });
 
   it('shows only the current folder for folder style', () => {
@@ -14,55 +15,79 @@ describe('formatPathPreview', () => {
   });
 
   it('shows the full path for full style', () => {
-    expect(formatPathPreview({ style: 'full' })).toBe('~/dev/my-app');
-  });
-
-  it('abbreviates parent folders to first letter for letter style', () => {
-    expect(formatPathPreview({ style: 'letter' })).toBe('~/d/my-app');
-  });
-
-  it('replaces intermediate folders with the folder icon for agnoster style', () => {
-    expect(formatPathPreview({ style: 'agnoster' })).toBe('~/../my-app');
+    expect(formatPathPreview({ style: 'full' })).toBe('~/projects/src/my-app');
   });
 
   it('shows all folders for agnoster_full style', () => {
-    expect(formatPathPreview({ style: 'agnoster_full' })).toBe('~/dev/my-app');
+    expect(formatPathPreview({ style: 'agnoster_full' })).toBe('~/projects/src/my-app');
   });
 
-  it('shortens from the right for agnoster_left style', () => {
-    expect(formatPathPreview({ style: 'agnoster_left' })).toBe('~/dev/..');
+  it('replaces intermediate folders with the folder icon for agnoster style', () => {
+    expect(formatPathPreview({ style: 'agnoster' })).toBe('~/../../my-app');
+  });
+
+  it('shows root, one folder icon, and the last max_depth folders for agnoster_short', () => {
+    expect(formatPathPreview({ style: 'agnoster_short' })).toBe('~/../my-app');
+    expect(formatPathPreview({ style: 'agnoster_short', max_depth: 2 })).toBe('~/../src/my-app');
   });
 
   it('hides the root location for agnoster_short with hide_root_location', () => {
     expect(formatPathPreview({ style: 'agnoster_short', hide_root_location: true })).toBe('../my-app');
+    expect(formatPathPreview({ style: 'agnoster_short', hide_root_location: true, max_depth: 2 })).toBe('../src/my-app');
+  });
+
+  it('shows the full path for agnoster_short when max_depth covers the whole path', () => {
+    expect(formatPathPreview({ style: 'agnoster_short', max_depth: 3 })).toBe('~/projects/src/my-app');
+  });
+
+  it('keeps the first folder and its child, then folder icons, for agnoster_left', () => {
+    expect(formatPathPreview({ style: 'agnoster_left' })).toBe('~/projects/../..');
+  });
+
+  it('abbreviates every folder but the last to its first letter for letter style', () => {
+    expect(formatPathPreview({ style: 'letter' })).toBe('~/p/s/my-app');
+  });
+
+  it('abbreviates like letter for unique style', () => {
+    expect(formatPathPreview({ style: 'unique' })).toBe('~/p/s/my-app');
+  });
+
+  it('shortens folders to dir_length chars for fish style', () => {
+    expect(formatPathPreview({ style: 'fish' })).toBe('~/p/s/my-app');
+    expect(formatPathPreview({ style: 'fish', dir_length: 2 })).toBe('~/pr/sr/my-app');
+  });
+
+  it('keeps the last full_length_dirs folders complete for fish style', () => {
+    expect(formatPathPreview({ style: 'fish', full_length_dirs: 2 })).toBe('~/p/src/my-app');
   });
 
   it('keeps short folders and abbreviates long ones for mixed style', () => {
-    // 'dev' (3 chars) is within the default mixed_threshold of 4
-    expect(formatPathPreview({ style: 'mixed' })).toBe('~/dev/my-app');
-    // threshold 2 pushes 'dev' over the limit
-    expect(formatPathPreview({ style: 'mixed', mixed_threshold: 2 })).toBe('~/../my-app');
+    // 'projects' (8 chars) exceeds the default mixed_threshold of 4, 'src' (3) does not
+    expect(formatPathPreview({ style: 'mixed' })).toBe('~/../src/my-app');
+    expect(formatPathPreview({ style: 'mixed', mixed_threshold: 2 })).toBe('~/../../my-app');
+    expect(formatPathPreview({ style: 'mixed', mixed_threshold: 8 })).toBe('~/projects/src/my-app');
   });
 
-  it('abbreviates like letter for unique and fish styles', () => {
-    expect(formatPathPreview({ style: 'unique' })).toBe('~/d/my-app');
-    expect(formatPathPreview({ style: 'fish' })).toBe('~/d/my-app');
+  it('shows the full path for powerlevel unless max_width is exceeded', () => {
+    expect(formatPathPreview({ style: 'powerlevel' })).toBe('~/projects/src/my-app');
+    expect(formatPathPreview({ style: 'powerlevel', max_width: 12 })).toBe('~/p/s/my-app');
+    expect(formatPathPreview({ style: 'powerlevel', max_width: 100 })).toBe('~/projects/src/my-app');
   });
 
   it('honors folder_separator_icon', () => {
-    expect(formatPathPreview({ style: 'full', folder_separator_icon: ' > ' })).toBe('~ > dev > my-app');
+    expect(formatPathPreview({ style: 'full', folder_separator_icon: ' > ' })).toBe('~ > projects > src > my-app');
   });
 
   it('honors home_icon', () => {
-    expect(formatPathPreview({ style: 'full', home_icon: '🏠' })).toBe('🏠/dev/my-app');
+    expect(formatPathPreview({ style: 'full', home_icon: '🏠' })).toBe('🏠/projects/src/my-app');
   });
 
   it('honors folder_icon for agnoster style', () => {
-    expect(formatPathPreview({ style: 'agnoster', folder_icon: '…' })).toBe('~/…/my-app');
+    expect(formatPathPreview({ style: 'agnoster', folder_icon: '…' })).toBe('~/…/…/my-app');
   });
 
   it('falls back to the full path for unknown styles', () => {
-    expect(formatPathPreview({ style: 'powerlevel' })).toBe('~/dev/my-app');
+    expect(formatPathPreview({ style: 'no-such-style' })).toBe('~/projects/src/my-app');
   });
 });
 
@@ -71,23 +96,23 @@ describe('getPreviewText for path segment with style options', () => {
     id: 'test-path',
     type: 'path',
     style: 'powerline',
-    template: '  {{ .Path }} ',
+    template: '  {{ .Path }} ',
     options,
   });
 
   it('renders the letter style in the preview text', () => {
     const text = getPreviewText(makePathSegment({ style: 'letter' }), undefined, true);
-    expect(text).toContain('~/d/my-app');
+    expect(text).toContain('~/p/s/my-app');
   });
 
   it('renders the folder style in the preview text', () => {
     const text = getPreviewText(makePathSegment({ style: 'folder' }), undefined, true);
     expect(text).toContain('my-app');
-    expect(text).not.toContain('~/dev/my-app');
+    expect(text).not.toContain('~/projects/src/my-app');
   });
 
   it('keeps the default preview when no options are set', () => {
     const text = getPreviewText(makePathSegment(), undefined, true);
-    expect(text).toContain('~/dev/my-app');
+    expect(text).toContain('~/projects/src/my-app');
   });
 });

--- a/src/components/PreviewPanel/__tests__/pathPreview.test.ts
+++ b/src/components/PreviewPanel/__tests__/pathPreview.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { formatPathPreview } from '../pathPreview';
+import { getPreviewText } from '../templateUtils';
+import type { Segment } from '../../../types/ohmyposh';
+
+describe('formatPathPreview', () => {
+  it('returns the full mock path when no options are set', () => {
+    expect(formatPathPreview()).toBe('~/dev/my-app');
+    expect(formatPathPreview({})).toBe('~/dev/my-app');
+  });
+
+  it('shows only the current folder for folder style', () => {
+    expect(formatPathPreview({ style: 'folder' })).toBe('my-app');
+  });
+
+  it('shows the full path for full style', () => {
+    expect(formatPathPreview({ style: 'full' })).toBe('~/dev/my-app');
+  });
+
+  it('abbreviates parent folders to first letter for letter style', () => {
+    expect(formatPathPreview({ style: 'letter' })).toBe('~/d/my-app');
+  });
+
+  it('replaces intermediate folders with the folder icon for agnoster style', () => {
+    expect(formatPathPreview({ style: 'agnoster' })).toBe('~/../my-app');
+  });
+
+  it('shows all folders for agnoster_full style', () => {
+    expect(formatPathPreview({ style: 'agnoster_full' })).toBe('~/dev/my-app');
+  });
+
+  it('shortens from the right for agnoster_left style', () => {
+    expect(formatPathPreview({ style: 'agnoster_left' })).toBe('~/dev/..');
+  });
+
+  it('hides the root location for agnoster_short with hide_root_location', () => {
+    expect(formatPathPreview({ style: 'agnoster_short', hide_root_location: true })).toBe('../my-app');
+  });
+
+  it('keeps short folders and abbreviates long ones for mixed style', () => {
+    // 'dev' (3 chars) is within the default mixed_threshold of 4
+    expect(formatPathPreview({ style: 'mixed' })).toBe('~/dev/my-app');
+    // threshold 2 pushes 'dev' over the limit
+    expect(formatPathPreview({ style: 'mixed', mixed_threshold: 2 })).toBe('~/../my-app');
+  });
+
+  it('abbreviates like letter for unique and fish styles', () => {
+    expect(formatPathPreview({ style: 'unique' })).toBe('~/d/my-app');
+    expect(formatPathPreview({ style: 'fish' })).toBe('~/d/my-app');
+  });
+
+  it('honors folder_separator_icon', () => {
+    expect(formatPathPreview({ style: 'full', folder_separator_icon: ' > ' })).toBe('~ > dev > my-app');
+  });
+
+  it('honors home_icon', () => {
+    expect(formatPathPreview({ style: 'full', home_icon: '🏠' })).toBe('🏠/dev/my-app');
+  });
+
+  it('honors folder_icon for agnoster style', () => {
+    expect(formatPathPreview({ style: 'agnoster', folder_icon: '…' })).toBe('~/…/my-app');
+  });
+
+  it('falls back to the full path for unknown styles', () => {
+    expect(formatPathPreview({ style: 'powerlevel' })).toBe('~/dev/my-app');
+  });
+});
+
+describe('getPreviewText for path segment with style options', () => {
+  const makePathSegment = (options?: Record<string, unknown>): Segment => ({
+    id: 'test-path',
+    type: 'path',
+    style: 'powerline',
+    template: '  {{ .Path }} ',
+    options,
+  });
+
+  it('renders the letter style in the preview text', () => {
+    const text = getPreviewText(makePathSegment({ style: 'letter' }), undefined, true);
+    expect(text).toContain('~/d/my-app');
+  });
+
+  it('renders the folder style in the preview text', () => {
+    const text = getPreviewText(makePathSegment({ style: 'folder' }), undefined, true);
+    expect(text).toContain('my-app');
+    expect(text).not.toContain('~/dev/my-app');
+  });
+
+  it('keeps the default preview when no options are set', () => {
+    const text = getPreviewText(makePathSegment(), undefined, true);
+    expect(text).toContain('~/dev/my-app');
+  });
+});

--- a/src/components/PreviewPanel/mockData.ts
+++ b/src/components/PreviewPanel/mockData.ts
@@ -1,6 +1,8 @@
 // Mock data for preview - organized by segment type for easy maintenance
 // Each segment type has its own complete set of mock data
 
+import { formatPathPreview } from './pathPreview';
+
 // Shared data available to all segments (cross-segment references, environment)
 const sharedMockData: Record<string, unknown> = {
   // Environment variables (accessible via .Env.*)
@@ -1018,11 +1020,17 @@ export const mockData: Record<string, unknown> = {
 export const segmentTypeOverrides = segmentMockData;
 
 // Helper to get mock data with segment-specific data merged with shared data
-export function getMockDataForSegment(segmentType: string): Record<string, unknown> {
+export function getMockDataForSegment(
+  segmentType: string,
+  segmentOptions?: Record<string, unknown>
+): Record<string, unknown> {
   const segmentData = segmentMockData[segmentType];
-  if (segmentData) {
-    return { ...sharedMockData, ...segmentData };
+  const base = segmentData
+    ? { ...sharedMockData, ...segmentData }
+    : { ...sharedMockData, ...mockData };
+  // The path segment's display depends on its style options (style, separators, icons)
+  if (segmentType === 'path') {
+    return { ...base, Path: formatPathPreview(segmentOptions) };
   }
-  // Fallback to shared + default mock data
-  return { ...sharedMockData, ...mockData };
+  return base;
 }

--- a/src/components/PreviewPanel/mockData.ts
+++ b/src/components/PreviewPanel/mockData.ts
@@ -51,9 +51,9 @@ const sharedMockData: Record<string, unknown> = {
       },
     },
     Path: {
-      Path: '~/dev/my-app',
+      Path: '~/projects/src/my-app',
       Folder: 'my-app',
-      Location: '~/dev/my-app',
+      Location: '~/projects/src/my-app',
     },
     Session: {
       UserName: 'user',
@@ -112,11 +112,11 @@ export const segmentMockData: Record<string, Record<string, unknown>> = {
   },
   
   path: {
-    Path: '~/dev/my-app',
+    Path: '~/projects/src/my-app',
     Folder: 'my-app',
-    Parent: '~/dev/',
-    Location: '~/dev/my-app',
-    PWD: '/home/user/dev/my-app',
+    Parent: '~/projects/src/',
+    Location: '~/projects/src/my-app',
+    PWD: '/home/user/projects/src/my-app',
     RootDir: false,
     StackCount: 0,
     Writable: true,

--- a/src/components/PreviewPanel/pathPreview.ts
+++ b/src/components/PreviewPanel/pathPreview.ts
@@ -1,49 +1,96 @@
 // Formats the mock preview path according to the path segment's style options.
-// Mirrors (approximately) how Oh My Posh renders the path segment styles:
+// Mirrors how Oh My Posh renders the path segment styles:
 // https://ohmyposh.dev/docs/segments/system/path
 
-const MOCK_PATH_FOLDERS = ['~', 'dev', 'my-app'];
+const MOCK_PATH_FOLDERS = ['~', 'projects', 'src', 'my-app'];
 const DEFAULT_FOLDER_SEPARATOR = '/';
 const DEFAULT_HOME_ICON = '~';
 const DEFAULT_FOLDER_ICON = '..';
 const DEFAULT_MIXED_THRESHOLD = 4;
+const DEFAULT_MAX_DEPTH = 1;
+const DEFAULT_DIR_LENGTH = 1;
+const DEFAULT_FULL_LENGTH_DIRS = 1;
+
+function stringOption(options: Record<string, unknown> | undefined, key: string, fallback: string): string {
+  const value = options?.[key];
+  return typeof value === 'string' ? value : fallback;
+}
+
+function numberOption(options: Record<string, unknown> | undefined, key: string, fallback: number): number {
+  const value = options?.[key];
+  return typeof value === 'number' && value > 0 ? value : fallback;
+}
 
 export function formatPathPreview(options?: Record<string, unknown>): string {
   const style = typeof options?.style === 'string' ? options.style : undefined;
-  const separator = typeof options?.folder_separator_icon === 'string'
-    ? options.folder_separator_icon
-    : DEFAULT_FOLDER_SEPARATOR;
-  const homeIcon = typeof options?.home_icon === 'string' ? options.home_icon : DEFAULT_HOME_ICON;
-  const folderIcon = typeof options?.folder_icon === 'string' ? options.folder_icon : DEFAULT_FOLDER_ICON;
+  const separator = stringOption(options, 'folder_separator_icon', DEFAULT_FOLDER_SEPARATOR);
+  const homeIcon = stringOption(options, 'home_icon', DEFAULT_HOME_ICON);
+  const folderIcon = stringOption(options, 'folder_icon', DEFAULT_FOLDER_ICON);
 
   const folders = MOCK_PATH_FOLDERS.map((name, index) => (index === 0 ? homeIcon : name));
   const root = folders[0];
   const middle = folders.slice(1, -1);
   const last = folders[folders.length - 1];
+  const fullPath = folders.join(separator);
+
+  // Every folder except the root and the last shortened to its first letter
+  const letterPath = [root, ...middle.map((name) => name.charAt(0)), last].join(separator);
 
   switch (style) {
+    // Only the name of the current folder
     case 'folder':
       return last;
+    // First and last folder as-is, every intermediate folder as the folder icon
     case 'agnoster':
       return [root, ...middle.map(() => folderIcon), last].join(separator);
+    // Root (unless hidden), one folder icon, then the last max_depth folders
     case 'agnoster_short': {
+      const maxDepth = numberOption(options, 'max_depth', DEFAULT_MAX_DEPTH);
+      const tail = folders.slice(1);
+      if (maxDepth >= tail.length) {
+        return fullPath;
+      }
+      const shown = tail.slice(-maxDepth);
       const hideRoot = options?.hide_root_location === true;
-      return (hideRoot ? [folderIcon, last] : [root, folderIcon, last]).join(separator);
+      return (hideRoot ? [folderIcon, ...shown] : [root, folderIcon, ...shown]).join(separator);
     }
-    case 'agnoster_left':
-      return [root, ...middle, folderIcon].join(separator);
+    // First folder and its child as-is, every following folder as the folder icon
+    case 'agnoster_left': {
+      const rest = folders.slice(2);
+      return [root, ...folders.slice(1, 2), ...rest.map(() => folderIcon)].join(separator);
+    }
+    // letter: first letter of every folder except the last
+    // unique: shortest unique prefix — equals letter for the mock path (no sibling folders to disambiguate)
     case 'letter':
     case 'unique':
-    case 'fish':
-      return [root, ...middle.map((name) => name.charAt(0)), last].join(separator);
+      return letterPath;
+    // dir_length chars per folder, the last full_length_dirs folders in full
+    case 'fish': {
+      const dirLength = numberOption(options, 'dir_length', DEFAULT_DIR_LENGTH);
+      const fullLengthDirs = numberOption(options, 'full_length_dirs', DEFAULT_FULL_LENGTH_DIRS);
+      const shortened = folders.map((name, index) => {
+        if (index === 0 || index >= folders.length - fullLengthDirs) {
+          return name;
+        }
+        return name.substring(0, dirLength);
+      });
+      return shortened.join(separator);
+    }
+    // Intermediate folders longer than mixed_threshold become the folder icon
     case 'mixed': {
-      const threshold = typeof options?.mixed_threshold === 'number'
-        ? options.mixed_threshold
-        : DEFAULT_MIXED_THRESHOLD;
+      const threshold = numberOption(options, 'mixed_threshold', DEFAULT_MIXED_THRESHOLD);
       return [root, ...middle.map((name) => (name.length > threshold ? folderIcon : name)), last].join(separator);
     }
-    // full, agnoster_full, powerlevel, and unset/unknown styles show the full path
+    // Full path, shortened letter-style when it exceeds max_width
+    case 'powerlevel': {
+      const maxWidth = numberOption(options, 'max_width', 0);
+      if (maxWidth > 0 && fullPath.length > maxWidth) {
+        return letterPath;
+      }
+      return fullPath;
+    }
+    // full, agnoster_full, and unset/unknown styles show the full path
     default:
-      return folders.join(separator);
+      return fullPath;
   }
 }

--- a/src/components/PreviewPanel/pathPreview.ts
+++ b/src/components/PreviewPanel/pathPreview.ts
@@ -1,0 +1,49 @@
+// Formats the mock preview path according to the path segment's style options.
+// Mirrors (approximately) how Oh My Posh renders the path segment styles:
+// https://ohmyposh.dev/docs/segments/system/path
+
+const MOCK_PATH_FOLDERS = ['~', 'dev', 'my-app'];
+const DEFAULT_FOLDER_SEPARATOR = '/';
+const DEFAULT_HOME_ICON = '~';
+const DEFAULT_FOLDER_ICON = '..';
+const DEFAULT_MIXED_THRESHOLD = 4;
+
+export function formatPathPreview(options?: Record<string, unknown>): string {
+  const style = typeof options?.style === 'string' ? options.style : undefined;
+  const separator = typeof options?.folder_separator_icon === 'string'
+    ? options.folder_separator_icon
+    : DEFAULT_FOLDER_SEPARATOR;
+  const homeIcon = typeof options?.home_icon === 'string' ? options.home_icon : DEFAULT_HOME_ICON;
+  const folderIcon = typeof options?.folder_icon === 'string' ? options.folder_icon : DEFAULT_FOLDER_ICON;
+
+  const folders = MOCK_PATH_FOLDERS.map((name, index) => (index === 0 ? homeIcon : name));
+  const root = folders[0];
+  const middle = folders.slice(1, -1);
+  const last = folders[folders.length - 1];
+
+  switch (style) {
+    case 'folder':
+      return last;
+    case 'agnoster':
+      return [root, ...middle.map(() => folderIcon), last].join(separator);
+    case 'agnoster_short': {
+      const hideRoot = options?.hide_root_location === true;
+      return (hideRoot ? [folderIcon, last] : [root, folderIcon, last]).join(separator);
+    }
+    case 'agnoster_left':
+      return [root, ...middle, folderIcon].join(separator);
+    case 'letter':
+    case 'unique':
+    case 'fish':
+      return [root, ...middle.map((name) => name.charAt(0)), last].join(separator);
+    case 'mixed': {
+      const threshold = typeof options?.mixed_threshold === 'number'
+        ? options.mixed_threshold
+        : DEFAULT_MIXED_THRESHOLD;
+      return [root, ...middle.map((name) => (name.length > threshold ? folderIcon : name)), last].join(separator);
+    }
+    // full, agnoster_full, powerlevel, and unset/unknown styles show the full path
+    default:
+      return folders.join(separator);
+  }
+}

--- a/src/components/PreviewPanel/templateUtils.tsx
+++ b/src/components/PreviewPanel/templateUtils.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import type { Segment } from '../../types/ohmyposh';
 import { getMockDataForSegment } from './mockData';
+import { formatPathPreview } from './pathPreview';
 import { 
   resolvePaletteColor, 
   isHexColor,
@@ -190,7 +191,7 @@ export function getPreviewText(
     
     // Handle path function - {{ path (.Format .Path) .Location }}
     result = result.replace(/\{\{\s*path\s+(?:\([^)]+\)|\.[\w.]+)\s+\.[\w.]+\s*\}\}/g, () => {
-      return getNestedValue('Path') || '~/dev/my-app';
+      return getNestedValue('Path') || formatPathPreview(segment.options);
     });
     
     // Handle now | date - {{ now | date "15:04:05" }}

--- a/src/components/PreviewPanel/templateUtils.tsx
+++ b/src/components/PreviewPanel/templateUtils.tsx
@@ -145,7 +145,7 @@ export function getPreviewText(
     
     // Get segment-specific mock data (handles .Icon differently for music vs battery vs os)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const segmentMockData = getMockDataForSegment(segment.type) as Record<string, any>;
+    const segmentMockData = getMockDataForSegment(segment.type, segment.options) as Record<string, any>;
     
     // Helper to get nested value from mock data
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -371,7 +371,7 @@ export function getPreviewText(
   }
   
   // Third priority: generate preview based on segment type using segment-specific mock data
-  const segmentData = getMockDataForSegment(segment.type);
+  const segmentData = getMockDataForSegment(segment.type, segment.options);
   
   // Build preview text from segment's mock data
   const typeMap: Record<string, () => string> = {


### PR DESCRIPTION
## Problem

Changing the path segment's `style` option (e.g. to `letter`) updates the config JSON but the preview never changes — it always shows the same hardcoded path.

Root cause: the preview's mock data is keyed only by segment type (`getMockDataForSegment(segment.type)`), so `segment.options` never reaches the preview. The mock `Path` value is a hardcoded constant. Every path option was dead in the preview: `style`, `folder_separator_icon`, `home_icon`, `folder_icon`, `mixed_threshold`, `max_depth`, `hide_root_location`, `dir_length`, `full_length_dirs`, `max_width`.

## Fix

- New `formatPathPreview(options)` in `src/components/PreviewPanel/pathPreview.ts` formats a mock path (`~/projects/src/my-app` — deep enough that every style renders distinctly) per the documented style semantics (https://ohmyposh.dev/docs/segments/system/path):

  | style | preview |
  |---|---|
  | `folder` | `my-app` |
  | `full` / `agnoster_full` / `powerlevel` | `~/projects/src/my-app` |
  | `agnoster` | `~/../../my-app` |
  | `agnoster_short` (max_depth 1) | `~/../my-app` |
  | `agnoster_left` | `~/projects/../..` |
  | `mixed` (threshold 4) | `~/../src/my-app` |
  | `letter` / `unique` / `fish` | `~/p/s/my-app` |

  Styles that coincide above do so because Oh My Posh itself renders them identically for this path (no sibling dirs for `unique`, defaults for `fish`/`powerlevel`).
- Honors `folder_separator_icon`, `home_icon`, `folder_icon`, `mixed_threshold`, `max_depth`, `hide_root_location`, `dir_length`, `full_length_dirs`, `max_width`.
- `getMockDataForSegment` accepts the segment's options and overrides the mock `Path` for path segments; both preview call sites in `templateUtils.tsx` pass `segment.options`.

## Testing

- 22 vitest tests (unit for the formatter + integration through `getPreviewText`), full suite green (260 tests).
- Verified end-to-end in the running app: cycling Style on the default Path segment updates the preview immediately with the values in the table above, and the exported config stays in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)