### PR TITLE
Align configurator themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to the Oh My Posh Visual Configurator project will be docume
 
 ### Fixed
 
+- Kept theme initialization and switching functional when browser local storage is unavailable, while keeping the browser theme color synchronized.
 - Improved light and dark theme contrast across settings, supporting copy, and legacy accent utilities to meet WCAG AA text contrast requirements.
 - Matched Studio Beta setup, loading, and error states to the configurator panel background while preserving the selected terminal background for rendered prompts.
 - Updated Theme Library modal surfaces, tabs, cards, and controls to follow the active light or dark theme.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to the Oh My Posh Visual Configurator project will be docume
 
 ## [2026-08-01]
 
+### Changed: Compact Header Controls
+
+- Kept reset, settings, and theme actions icon-only below the desktop workspace breakpoint to preserve room for compact editing controls.
+- Reordered compact header actions so the theme control is separated from Settings by the Theme Library button.
+
+### Changed: Site Theme Alignment
+
+- Aligned the configurator with the official Oh My Posh light and dark theme palette, including a persistent header toggle and matching Inter typography.
+
+### Fixed
+
+- Improved light and dark theme contrast across settings, supporting copy, and legacy accent utilities to meet WCAG AA text contrast requirements.
+- Matched Studio Beta setup, loading, and error states to the configurator panel background while preserving the selected terminal background for rendered prompts.
+- Updated Theme Library modal surfaces, tabs, cards, and controls to follow the active light or dark theme.
+- Corrected Theme Library badge icon and label contrast in light and dark modes.
+
 ### Changed: Workspace Panel Controls
 
 - Added desktop controls that collapse the Segments and Properties sidebars into compact restore rails, giving the canvas more room without hiding either panel's access point

--- a/index.html
+++ b/index.html
@@ -14,8 +14,17 @@
     <meta name="author" content="James Montemagno" />
     <meta name="theme-color" content="#ffffff" />
     <script>
-      const theme = window.localStorage.getItem('theme') === 'dark' ? 'dark' : 'light';
+      let theme = 'light';
+      try {
+        theme = window.localStorage.getItem('theme') === 'dark' ? 'dark' : 'light';
+      } catch {
+        // Use the light theme when persistent storage is unavailable.
+      }
       document.documentElement.dataset.theme = theme;
+      document.querySelector('meta[name="theme-color"]')?.setAttribute(
+        'content',
+        theme === 'dark' ? '#1b1b1d' : '#ffffff'
+      );
     </script>
     
     <!-- Canonical URL -->

--- a/index.html
+++ b/index.html
@@ -12,7 +12,11 @@
     <meta name="description" content="Design and customize your Oh My Posh terminal prompt visually. Drag and drop segments, preview in real-time, and export your configuration instantly. Perfect for PowerShell, Bash, Zsh, and more." />
     <meta name="keywords" content="oh my posh, terminal, prompt, shell, customization, powerline, configuration, powershell, bash, zsh, fish, visual editor, terminal theme" />
     <meta name="author" content="James Montemagno" />
-    <meta name="theme-color" content="#0f3460" />
+    <meta name="theme-color" content="#ffffff" />
+    <script>
+      const theme = window.localStorage.getItem('theme') === 'dark' ? 'dark' : 'light';
+      document.documentElement.dataset.theme = theme;
+    </script>
     
     <!-- Canonical URL -->
     <link rel="canonical" href="https://configurator.ohmyposh.dev/" />
@@ -53,6 +57,7 @@
     <!-- Preconnect for performance -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
     <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600&display=swap" rel="stylesheet">
     
     <!-- Preload subset Nerd Font for performance -->

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -10,6 +10,9 @@ import { useRef, useState, useEffect } from 'react';
 export function Header() {
   const [showGitHubDropdown, setShowGitHubDropdown] = useState(false);
   const [showAdvancedSettings, setShowAdvancedSettings] = useState(false);
+  const [theme, setTheme] = useState<'light' | 'dark'>(() =>
+    document.documentElement.dataset.theme === 'dark' ? 'dark' : 'light'
+  );
   const githubDropdownRef = useRef<HTMLDivElement>(null);
   const resetConfig = useConfigStore((state) => state.resetConfig);
   const { lastLoadedId, configs, hasUnsavedChanges, clearLastLoadedId } = useSavedConfigsStore();
@@ -45,6 +48,15 @@ export function Header() {
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme;
+    window.localStorage.setItem('theme', theme);
+    document.querySelector('meta[name="theme-color"]')?.setAttribute(
+      'content',
+      theme === 'dark' ? '#1b1b1d' : '#ffffff'
+    );
+  }, [theme]);
+
   return (
     <header className="bg-[#16213e] border-b border-[#0f3460] px-2 sm:px-4 py-2 sm:py-3 flex items-center justify-between gap-2 flex-wrap relative">
       <div className="flex items-center gap-2 sm:gap-3 min-w-0 flex-1">
@@ -77,13 +89,24 @@ export function Header() {
       <div className="flex items-center gap-1 sm:gap-2 flex-shrink-0">
         <button
           onClick={handleResetConfig}
-          className="flex items-center gap-1.5 px-2 sm:px-3 py-1.5 text-sm text-gray-300 hover:text-red-400 hover:bg-red-900/20 rounded transition-colors"
+          className="flex items-center gap-1.5 px-2 sm:px-3 py-1.5 text-sm text-red-500 hover:text-red-200 hover:bg-red-900/20 rounded transition-colors"
           title="Reset to default configuration"
         >
           <NerdIcon icon="action-refresh" size={16} />
-          <span className="hidden sm:inline">Reset</span>
+          <span className="hidden xl:inline">Reset</span>
         </button>
         
+        <button
+          type="button"
+          onClick={() => setTheme((currentTheme) => currentTheme === 'light' ? 'dark' : 'light')}
+          className="flex items-center gap-1.5 px-2 sm:px-3 py-1.5 text-sm text-gray-300 hover:text-white hover:bg-[#0f3460] rounded transition-colors"
+          aria-label={`Use ${theme === 'light' ? 'dark' : 'light'} theme`}
+          title={`Use ${theme === 'light' ? 'dark' : 'light'} theme`}
+        >
+          <NerdIcon icon={theme === 'light' ? 'misc-moon' : 'weather-sunny'} size={16} />
+          <span className="hidden xl:inline">{theme === 'light' ? 'Dark' : 'Light'}</span>
+        </button>
+
         <SamplePicker />
         
         <button
@@ -92,7 +115,7 @@ export function Header() {
           title="Settings & Tools"
         >
           <NerdIcon icon="tool-settings" size={16} />
-          <span className="hidden sm:inline">Settings</span>
+          <span className="hidden xl:inline">Settings</span>
         </button>
 
         <div className="relative" ref={githubDropdownRef}>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -50,7 +50,11 @@ export function Header() {
 
   useEffect(() => {
     document.documentElement.dataset.theme = theme;
-    window.localStorage.setItem('theme', theme);
+    try {
+      window.localStorage.setItem('theme', theme);
+    } catch {
+      // Keep the selected theme active when persistent storage is unavailable.
+    }
     document.querySelector('meta[name="theme-color"]')?.setAttribute(
       'content',
       theme === 'dark' ? '#1b1b1d' : '#ffffff'

--- a/src/components/PreviewPanel/PreviewPanel.tsx
+++ b/src/components/PreviewPanel/PreviewPanel.tsx
@@ -57,7 +57,7 @@ export function PreviewPanel({ active = true }: PreviewPanelProps) {
                   : 'text-gray-400 hover:text-white'
               }`}
             >
-              Studio <span className="ml-0.5 opacity-80">Beta</span>
+              Studio <span className="ml-0.5">Beta</span>
             </button>
             <button
               type="button"
@@ -124,6 +124,7 @@ export function PreviewPanel({ active = true }: PreviewPanelProps) {
       <div className={previewRenderer === 'studio' ? 'contents' : 'hidden'}>
         <StudioPreview
           backgroundColor={bgColor}
+          textColor={textColor}
           active={active && previewRenderer === 'studio'}
         />
       </div>

--- a/src/components/PreviewPanel/StudioPreview.tsx
+++ b/src/components/PreviewPanel/StudioPreview.tsx
@@ -11,6 +11,7 @@ const HORIZONTAL_PADDING_PX = 32;
 
 interface StudioPreviewProps {
   backgroundColor: string;
+  textColor: string;
   active: boolean;
 }
 
@@ -20,7 +21,7 @@ function getStudioColumns(availableWidth: number): number {
   return Math.min(MAX_STUDIO_COLUMNS, Math.max(MIN_STUDIO_COLUMNS, columns));
 }
 
-export function StudioPreview({ backgroundColor, active }: StudioPreviewProps) {
+export function StudioPreview({ backgroundColor, textColor, active }: StudioPreviewProps) {
   const config = useConfigStore((state) => state.config);
   const setPreviewRenderer = useConfigStore((state) => state.setPreviewRenderer);
   const previewRef = useRef<HTMLDivElement>(null);
@@ -48,10 +49,7 @@ export function StudioPreview({ backgroundColor, active }: StudioPreviewProps) {
 
   if (status === 'idle') {
     return (
-      <div
-        className="flex-1 min-h-0 overflow-y-auto px-5 py-6 flex items-center justify-center"
-        style={{ backgroundColor }}
-      >
+      <div className="flex-1 min-h-0 overflow-y-auto px-5 py-6 flex items-center justify-center bg-[#16213e]">
         <div className="max-w-lg w-full flex items-start gap-4">
           <div className="mt-0.5 p-2 rounded-md bg-[#0f3460] text-blue-100 flex-shrink-0">
             <NerdIcon icon="misc-rocket" size={18} />
@@ -91,8 +89,7 @@ export function StudioPreview({ backgroundColor, active }: StudioPreviewProps) {
     const percent = Math.round(progress * 100);
     return (
       <div
-        className="flex-1 min-h-0 px-5 py-6 flex items-center justify-center"
-        style={{ backgroundColor }}
+        className="flex-1 min-h-0 px-5 py-6 flex items-center justify-center bg-[#16213e]"
         role="status"
         aria-live="polite"
       >
@@ -129,8 +126,7 @@ export function StudioPreview({ backgroundColor, active }: StudioPreviewProps) {
   if (status === 'error' && !svg) {
     return (
       <div
-        className="flex-1 min-h-0 px-5 py-6 flex items-center justify-center"
-        style={{ backgroundColor }}
+        className="flex-1 min-h-0 px-5 py-6 flex items-center justify-center bg-[#16213e]"
         role="alert"
       >
         <div className="w-full max-w-lg">
@@ -188,7 +184,7 @@ export function StudioPreview({ backgroundColor, active }: StudioPreviewProps) {
           dangerouslySetInnerHTML={{ __html: svg }}
         />
       ) : (
-        <p className="text-xs text-gray-400" role="status">
+        <p className="text-xs" style={{ color: textColor }} role="status">
           Rendering your prompt…
         </p>
       )}

--- a/src/components/SamplePicker/SamplePicker.tsx
+++ b/src/components/SamplePicker/SamplePicker.tsx
@@ -233,7 +233,7 @@ export function SamplePicker() {
       {/* Modal */}
       {isOpen && (
         <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4">
-          <div className="bg-[#1a1b2e] border border-gray-700 rounded-xl shadow-2xl max-w-4xl w-full max-h-[80vh] overflow-hidden flex flex-col">
+          <div className="theme-library border rounded-xl shadow-2xl max-w-4xl w-full max-h-[80vh] overflow-hidden flex flex-col">
             {/* Header */}
             <div className="flex items-center justify-between p-6 border-b border-gray-700">
               <div className="flex items-center gap-3">
@@ -356,7 +356,7 @@ export function SamplePicker() {
                     placeholder="Search themes by name or tag..."
                     value={searchQuery}
                     onChange={(e) => handleSearchChange(e.target.value)}
-                    className="w-full pl-10 pr-4 py-2 bg-gray-800 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:border-purple-500 transition-colors"
+                    className="w-full pl-10 pr-4 py-2 bg-[#0f0f23] border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:border-purple-500 transition-colors"
                   />
                   {searchQuery && (
                     <button

--- a/src/index.css
+++ b/src/index.css
@@ -28,9 +28,49 @@
 }
 
 :root {
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   line-height: 1.5;
   font-weight: 400;
+  --omp-primary: #1f6fd0;
+  --omp-primary-solid: #1f6fd0;
+  --omp-primary-hover: #1c64bb;
+  --omp-primary-soft: #ebf2fc;
+  --omp-background: #ffffff;
+  --omp-surface: #f5f6f7;
+  --omp-elevated: #ffffff;
+  --omp-control: #ebf2fc;
+  --omp-border: #ebedf0;
+  --omp-border-strong: #dadde1;
+  --omp-text: #1c1e21;
+  --omp-text-muted: #606770;
+  --omp-text-subtle: #606770;
+  --omp-success: #15803d;
+  --omp-success-solid: #15803d;
+  --omp-danger: #af272b;
+  --omp-warning: #854d0e;
+  --omp-warning-solid: #a16207;
+  color-scheme: light;
+}
+
+html[data-theme='dark'] {
+  --omp-primary: #5c9fee;
+  --omp-primary-solid: #1f6ed4;
+  --omp-primary-hover: #164e92;
+  --omp-primary-soft: #1f6ed4;
+  --omp-background: #1b1b1d;
+  --omp-surface: #242526;
+  --omp-elevated: #2e2f30;
+  --omp-control: #343b48;
+  --omp-border: #444950;
+  --omp-border-strong: #606770;
+  --omp-text: #f5f6f7;
+  --omp-text-muted: #bec3c9;
+  --omp-text-subtle: #bec3c9;
+  --omp-success: #4ade80;
+  --omp-success-solid: #166534;
+  --omp-danger: #fb7185;
+  --omp-warning: #fbbf24;
+  --omp-warning-solid: #a16207;
   color-scheme: dark;
 }
 
@@ -42,8 +82,9 @@ body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
-  background-color: #1a1a2e;
-  color: #eaeaea;
+  background-color: var(--omp-background);
+  color: var(--omp-text);
+  transition: background-color 150ms ease, color 150ms ease;
 }
 
 #root {
@@ -77,4 +118,232 @@ body {
   max-width: 100%;
   height: auto;
   font-family: 'Victor Mono', monospace;
+}
+
+.theme-library {
+  background-color: var(--omp-elevated);
+  border-color: var(--omp-border);
+  color: var(--omp-text);
+}
+
+.theme-library [class~="bg-[#16172e]"],
+.theme-library [class~="hover:bg-[#16172e]"]:hover {
+  background-color: var(--omp-elevated) !important;
+}
+
+.theme-library [class~="bg-gray-700"],
+.theme-library [class~="hover:bg-gray-700"]:hover,
+.theme-library [class~="hover:bg-gray-600"]:hover {
+  background-color: var(--omp-control) !important;
+}
+
+.theme-library [class~="border-gray-700"],
+.theme-library [class~="border-gray-600"] {
+  border-color: var(--omp-border) !important;
+}
+
+.theme-library [class~="border-purple-500"],
+.theme-library [class~="hover:border-purple-500"]:hover {
+  border-color: var(--omp-primary) !important;
+}
+
+[class~="bg-purple-600"] {
+  background-color: var(--omp-primary-solid) !important;
+}
+
+[class~="hover:bg-purple-700"]:hover {
+  background-color: var(--omp-primary-hover) !important;
+}
+
+/*
+ * Existing workspace components use the original utility palette directly.
+ * These aliases make that shared vocabulary follow the same two color modes
+ * as ohmyposh.dev while the components keep their established interaction states.
+ */
+[class~="bg-[#0f0f23]"] {
+  background-color: var(--omp-background) !important;
+}
+
+[class~="bg-[#16213e]"] {
+  background-color: var(--omp-surface) !important;
+}
+
+[class~="bg-[#1a1a2e]"] {
+  background-color: var(--omp-elevated) !important;
+}
+
+[class~="bg-[#0f3460]"] {
+  background-color: var(--omp-control) !important;
+}
+
+[class~="bg-[#e94560]"] {
+  background-color: var(--omp-primary-solid) !important;
+}
+
+[class~="bg-[#e94560]/20"] {
+  background-color: color-mix(in srgb, var(--omp-primary) 20%, transparent) !important;
+}
+
+[class~="border-[#0f3460]"] {
+  border-color: var(--omp-border) !important;
+}
+
+[class~="border-[#e94560]"],
+[class~="focus:border-[#e94560]"]:focus,
+[class~="focus-visible:outline-[#e94560]"]:focus-visible {
+  border-color: var(--omp-primary) !important;
+  outline-color: var(--omp-primary) !important;
+}
+
+[class~="hover:bg-[#1a1a2e]"]:hover {
+  background-color: var(--omp-elevated) !important;
+}
+
+[class~="hover:bg-[#0f3460]"]:hover {
+  background-color: var(--omp-control) !important;
+}
+
+[class~="hover:bg-[#1a4a7a]"]:hover {
+  background-color: var(--omp-primary-hover) !important;
+}
+
+[class~="hover:bg-[#d63850]"]:hover {
+  background-color: var(--omp-primary-hover) !important;
+}
+
+[class~="hover:bg-[#e94560]/80"]:hover {
+  background-color: color-mix(in srgb, var(--omp-primary) 80%, var(--omp-background)) !important;
+}
+
+.peer:checked ~ [class~="peer-checked:bg-[#e94560]"] {
+  background-color: var(--omp-primary-solid) !important;
+}
+
+[class~="hover:border-gray-500"]:hover {
+  border-color: var(--omp-border-strong) !important;
+}
+
+[class~="text-[#e94560]"],
+[class~="text-purple-400"],
+[class~="text-blue-400"] {
+  color: var(--omp-primary) !important;
+}
+
+[class~="text-green-400"] {
+  color: var(--omp-success) !important;
+}
+
+[class~="text-red-400"],
+[class~="text-red-500"] {
+  color: var(--omp-danger) !important;
+}
+
+[class~="text-amber-500"] {
+  color: var(--omp-warning) !important;
+}
+
+[class~="bg-amber-600"],
+[class~="hover:bg-amber-500"]:hover {
+  background-color: var(--omp-warning-solid) !important;
+}
+
+html[data-theme='light'] [class~="bg-blue-900/30"],
+html[data-theme='light'] [class~="bg-blue-900/50"],
+html[data-theme='light'] [class~="bg-purple-900/30"],
+html[data-theme='light'] [class~="bg-purple-900/50"] {
+  background-color: var(--omp-primary-soft) !important;
+}
+
+html[data-theme='light'] [class~="bg-green-900/30"],
+html[data-theme='light'] [class~="bg-green-900/50"] {
+  background-color: color-mix(in srgb, var(--omp-success) 12%, var(--omp-background)) !important;
+}
+
+html[data-theme='light'] [class~="bg-amber-900/30"],
+html[data-theme='light'] [class~="bg-amber-900/50"] {
+  background-color: color-mix(in srgb, var(--omp-warning) 12%, var(--omp-background)) !important;
+}
+
+html[data-theme='light'] [class~="border-blue-700"],
+html[data-theme='light'] [class~="border-purple-700"] {
+  border-color: var(--omp-primary) !important;
+}
+
+html[data-theme='light'] [class~="border-green-700"] {
+  border-color: var(--omp-success) !important;
+}
+
+html[data-theme='light'] [class~="border-amber-700"] {
+  border-color: var(--omp-warning) !important;
+}
+
+html[data-theme='light'] [class~="text-blue-300"],
+html[data-theme='light'] [class~="text-purple-300"] {
+  color: var(--omp-primary-hover) !important;
+}
+
+html[data-theme='light'] [class~="text-green-300"] {
+  color: var(--omp-success) !important;
+}
+
+html[data-theme='light'] [class~="text-amber-100"],
+html[data-theme='light'] [class~="text-amber-200"],
+html[data-theme='light'] [class~="text-amber-300"],
+html[data-theme='light'] [class~="text-amber-400"] {
+  color: var(--omp-warning) !important;
+}
+
+[class~="text-gray-200"] {
+  color: var(--omp-text) !important;
+}
+
+[class~="text-gray-300"] {
+  color: var(--omp-text-muted) !important;
+}
+
+[class~="text-gray-400"] {
+  color: var(--omp-text-muted) !important;
+}
+
+[class~="text-gray-500"],
+[class~="text-gray-600"] {
+  color: var(--omp-text-subtle) !important;
+}
+
+[class~="hover:text-gray-200"]:hover,
+[class~="hover:text-gray-300"]:hover,
+[class~="hover:text-white"]:hover {
+  color: var(--omp-text) !important;
+}
+
+html[data-theme='light'] [class~="text-white"] {
+  color: var(--omp-text) !important;
+}
+
+html[data-theme='light'] [class~="bg-[#e94560]"][class~="text-white"],
+html[data-theme='light'] [class~="bg-purple-600"][class~="text-white"],
+html[data-theme='light'] [class~="bg-amber-600"][class~="text-white"],
+html[data-theme='light'] button[class~="text-white"] [class~="text-white"] {
+  color: #ffffff !important;
+}
+
+/* Filled Theme Library badges need white icon and label text in light mode too. */
+html[data-theme='light'] .theme-library [class~="bg-purple-600"] [class~="text-white"],
+html[data-theme='light'] .theme-library [class~="bg-green-600"][class~="text-white"],
+html[data-theme='light'] .theme-library [class~="bg-green-600"] [class~="text-white"] {
+  color: #ffffff !important;
+}
+
+.theme-library [class~="bg-green-600"] {
+  background-color: var(--omp-success-solid) !important;
+}
+
+html[data-theme='light'] [class~="border-purple-500/50"] {
+  border-color: color-mix(in srgb, var(--omp-primary) 50%, transparent) !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body {
+    transition: none;
+  }
 }


### PR DESCRIPTION
## Summary
- align the configurator with the official light and dark palettes, including a persisted theme toggle
- improve responsive header actions, preview state contrast, and Theme Library surfaces
- retain the Studio terminal background while aligning its surrounding UI with the selected theme

## Validation
- `npm run lint`
- `npm run test -- --run`
- `npm run build`