### PR TITLE
Add export configuration syntax highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to the Oh My Posh Visual Configurator project will be docume
 - Kept reset, settings, and theme actions icon-only below the desktop workspace breakpoint to preserve room for compact editing controls.
 - Reordered compact header actions so the theme control is separated from Settings by the Theme Library button.
 
+### Added
+
+- Added theme-aware syntax highlighting for JSON, YAML, and TOML in the exported configuration viewer.
+
 ### Changed: Site Theme Alignment
 
 - Aligned the configurator with the official Oh My Posh light and dark theme palette, including a persistent header toggle and matching Inter typography.

--- a/src/components/ExportBar/ConfigCodePreview.tsx
+++ b/src/components/ExportBar/ConfigCodePreview.tsx
@@ -1,0 +1,33 @@
+import type { ExportFormat } from '../../types/ohmyposh';
+import { tokenizeConfig, type ConfigTokenType } from '../../utils/configSyntaxHighlight';
+
+interface ConfigCodePreviewProps {
+  content: string;
+  format: ExportFormat;
+}
+
+const tokenClassNames: Record<Exclude<ConfigTokenType, 'plain'>, string> = {
+  key: 'config-token-key',
+  string: 'config-token-string',
+  number: 'config-token-number',
+  boolean: 'config-token-boolean',
+  comment: 'config-token-comment',
+  punctuation: 'config-token-punctuation',
+};
+
+export function ConfigCodePreview({ content, format }: ConfigCodePreviewProps) {
+  const tokens = tokenizeConfig(content, format);
+
+  return (
+    <pre className="config-code-preview p-4 text-xs font-mono whitespace-pre-wrap" aria-label={`${format.toUpperCase()} configuration code`}>
+      {tokens.map((token, index) => (
+        <span
+          key={`${token.type}-${index}`}
+          className={token.type === 'plain' ? undefined : tokenClassNames[token.type]}
+        >
+          {token.value}
+        </span>
+      ))}
+    </pre>
+  );
+}

--- a/src/components/ExportBar/ExportBar.tsx
+++ b/src/components/ExportBar/ExportBar.tsx
@@ -7,6 +7,7 @@ import { exportConfig, downloadConfig, copyToClipboard } from '../../utils/confi
 import { ImportDialog } from '../ImportDialog';
 import { ShareDialog } from '../ShareDialog';
 import { SaveConfigDialog } from '../SaveConfigDialog';
+import { ConfigCodePreview } from './ConfigCodePreview';
 import type { ExportFormat } from '../../types/ohmyposh';
 
 const formatOptions: { value: ExportFormat; label: string; iconName: string }[] = [
@@ -200,9 +201,7 @@ export function ExportBar() {
 
       {showCode && (
         <div className="border-t border-[#0f3460] max-h-64 overflow-auto">
-          <pre className="p-4 text-xs font-mono text-gray-300 whitespace-pre-wrap">
-            {configContent}
-          </pre>
+          <ConfigCodePreview content={configContent} format={exportFormat} />
         </div>
       )}
 

--- a/src/index.css
+++ b/src/index.css
@@ -120,6 +120,47 @@ body {
   font-family: 'Victor Mono', monospace;
 }
 
+.config-code-preview {
+  color: var(--omp-text-muted);
+}
+
+.config-token-key {
+  color: var(--omp-primary-hover);
+}
+
+.config-token-string {
+  color: var(--omp-warning);
+}
+
+.config-token-number {
+  color: #6d28d9;
+}
+
+.config-token-boolean {
+  color: #a21caf;
+}
+
+.config-token-comment,
+.config-token-punctuation {
+  color: var(--omp-text-subtle);
+}
+
+html[data-theme='dark'] .config-token-key {
+  color: #a3cbf7;
+}
+
+html[data-theme='dark'] .config-token-string {
+  color: #fbbf24;
+}
+
+html[data-theme='dark'] .config-token-number {
+  color: #c4b5fd;
+}
+
+html[data-theme='dark'] .config-token-boolean {
+  color: #f9a8d4;
+}
+
 .theme-library {
   background-color: var(--omp-elevated);
   border-color: var(--omp-border);

--- a/src/utils/__tests__/configSyntaxHighlight.test.ts
+++ b/src/utils/__tests__/configSyntaxHighlight.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { tokenizeConfig } from '../configSyntaxHighlight';
+
+describe('tokenizeConfig', () => {
+  it('distinguishes JSON keys, values, and punctuation', () => {
+    const tokens = tokenizeConfig('{"version": 4, "enabled": true}', 'json');
+
+    expect(tokens).toContainEqual({ value: '"version"', type: 'key' });
+    expect(tokens).toContainEqual({ value: '4', type: 'number' });
+    expect(tokens).toContainEqual({ value: 'true', type: 'boolean' });
+    expect(tokens).toContainEqual({ value: '{', type: 'punctuation' });
+  });
+
+  it('distinguishes YAML keys, strings, and comments', () => {
+    const tokens = tokenizeConfig('version: 4 # current schema', 'yaml');
+
+    expect(tokens).toContainEqual({ value: 'version', type: 'key' });
+    expect(tokens).toContainEqual({ value: '4', type: 'number' });
+    expect(tokens).toContainEqual({ value: '# current schema', type: 'comment' });
+  });
+
+  it('distinguishes TOML table names, keys, and string values', () => {
+    const tokens = tokenizeConfig('[blocks]\ntype = "prompt"', 'toml');
+
+    expect(tokens).toContainEqual({ value: '[blocks]', type: 'key' });
+    expect(tokens).toContainEqual({ value: 'type', type: 'key' });
+    expect(tokens).toContainEqual({ value: '"prompt"', type: 'string' });
+  });
+});

--- a/src/utils/__tests__/configSyntaxHighlight.test.ts
+++ b/src/utils/__tests__/configSyntaxHighlight.test.ts
@@ -19,11 +19,31 @@ describe('tokenizeConfig', () => {
     expect(tokens).toContainEqual({ value: '# current schema', type: 'comment' });
   });
 
+  it('does not treat hashes in YAML quoted strings as comments', () => {
+    const tokens = tokenizeConfig('message: "hello # world" # comment', 'yaml');
+
+    expect(tokens).toContainEqual({ value: '"hello # world"', type: 'string' });
+    expect(tokens).toContainEqual({ value: '# comment', type: 'comment' });
+  });
+
+  it('only recognizes YAML comments when the hash follows whitespace', () => {
+    const tokens = tokenizeConfig('branch: feature#123', 'yaml');
+
+    expect(tokens).not.toContainEqual({ value: '#123', type: 'comment' });
+  });
+
   it('distinguishes TOML table names, keys, and string values', () => {
     const tokens = tokenizeConfig('[blocks]\ntype = "prompt"', 'toml');
 
     expect(tokens).toContainEqual({ value: '[blocks]', type: 'key' });
     expect(tokens).toContainEqual({ value: 'type', type: 'key' });
     expect(tokens).toContainEqual({ value: '"prompt"', type: 'string' });
+  });
+
+  it('does not treat hashes in TOML quoted strings as comments', () => {
+    const tokens = tokenizeConfig('title = "hello # world" # comment', 'toml');
+
+    expect(tokens).toContainEqual({ value: '"hello # world"', type: 'string' });
+    expect(tokens).toContainEqual({ value: '# comment', type: 'comment' });
   });
 });

--- a/src/utils/configSyntaxHighlight.ts
+++ b/src/utils/configSyntaxHighlight.ts
@@ -43,6 +43,37 @@ function tokenizeScalar(value: string): ConfigToken[] {
   return tokens;
 }
 
+function findCommentIndex(value: string, requiresWhitespace: boolean): number {
+  let quote: '"' | "'" | undefined;
+
+  for (let index = 0; index < value.length; index++) {
+    const character = value[index];
+
+    if (quote === '"') {
+      if (character === '\\') {
+        index++;
+      } else if (character === quote) {
+        quote = undefined;
+      }
+    } else if (quote === "'") {
+      if (character === "'" && value[index + 1] === "'") {
+        index++;
+      } else if (character === quote) {
+        quote = undefined;
+      }
+    } else if (character === '"' || character === "'") {
+      quote = character;
+    } else if (
+      character === '#' &&
+      (!requiresWhitespace || (index > 0 && /\s/.test(value[index - 1])))
+    ) {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
 function tokenizeJson(content: string): ConfigToken[] {
   const tokens: ConfigToken[] = [];
   const pattern = /("(?:\\.|[^"\\])*")(?=\s*:)|("(?:\\.|[^"\\])*")|(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)|\b(true|false|null)\b|([{}[\],:])/g;
@@ -84,7 +115,7 @@ function tokenizeYamlLine(line: string): ConfigToken[] {
   if (!match) return tokenizeScalar(line);
 
   const [, prefix, key, separator, value] = match;
-  const commentIndex = value.indexOf('#');
+  const commentIndex = findCommentIndex(value, true);
   const scalar = commentIndex === -1 ? value : value.slice(0, commentIndex);
   const comment = commentIndex === -1 ? '' : value.slice(commentIndex);
 
@@ -114,7 +145,7 @@ function tokenizeTomlLine(line: string): ConfigToken[] {
   if (!match) return tokenizeScalar(line);
 
   const [, prefix, key, separator, value] = match;
-  const commentIndex = value.indexOf('#');
+  const commentIndex = findCommentIndex(value, false);
   const scalar = commentIndex === -1 ? value : value.slice(0, commentIndex);
   const comment = commentIndex === -1 ? '' : value.slice(commentIndex);
 

--- a/src/utils/configSyntaxHighlight.ts
+++ b/src/utils/configSyntaxHighlight.ts
@@ -1,0 +1,139 @@
+import type { ExportFormat } from '../types/ohmyposh';
+
+export type ConfigTokenType =
+  | 'plain'
+  | 'key'
+  | 'string'
+  | 'number'
+  | 'boolean'
+  | 'comment'
+  | 'punctuation';
+
+export interface ConfigToken {
+  value: string;
+  type: ConfigTokenType;
+}
+
+function addToken(tokens: ConfigToken[], value: string, type: ConfigTokenType): void {
+  if (value) tokens.push({ value, type });
+}
+
+function tokenizeScalar(value: string): ConfigToken[] {
+  const tokens: ConfigToken[] = [];
+  const pattern = /("(?:\\.|[^"\\])*")|('(?:\\.|[^'\\])*')|(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)|\b(true|false|null)\b|([[\]{},])/g;
+  let position = 0;
+
+  for (const match of value.matchAll(pattern)) {
+    addToken(tokens, value.slice(position, match.index), 'plain');
+    addToken(
+      tokens,
+      match[0],
+      match[1] || match[2]
+        ? 'string'
+        : match[3]
+          ? 'number'
+          : match[4]
+            ? 'boolean'
+            : 'punctuation'
+    );
+    position = (match.index ?? 0) + match[0].length;
+  }
+
+  addToken(tokens, value.slice(position), 'plain');
+  return tokens;
+}
+
+function tokenizeJson(content: string): ConfigToken[] {
+  const tokens: ConfigToken[] = [];
+  const pattern = /("(?:\\.|[^"\\])*")(?=\s*:)|("(?:\\.|[^"\\])*")|(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)|\b(true|false|null)\b|([{}[\],:])/g;
+  let position = 0;
+
+  for (const match of content.matchAll(pattern)) {
+    addToken(tokens, content.slice(position, match.index), 'plain');
+    addToken(
+      tokens,
+      match[0],
+      match[1]
+        ? 'key'
+        : match[2]
+          ? 'string'
+          : match[3]
+            ? 'number'
+            : match[4]
+              ? 'boolean'
+              : 'punctuation'
+    );
+    position = (match.index ?? 0) + match[0].length;
+  }
+
+  addToken(tokens, content.slice(position), 'plain');
+  return tokens;
+}
+
+function tokenizeLines(content: string, tokenizeLine: (line: string) => ConfigToken[]): ConfigToken[] {
+  return content.split('\n').flatMap((line, index, lines) => [
+    ...tokenizeLine(line),
+    ...(index < lines.length - 1 ? [{ value: '\n', type: 'plain' as const }] : []),
+  ]);
+}
+
+function tokenizeYamlLine(line: string): ConfigToken[] {
+  if (line.trimStart().startsWith('#')) return [{ value: line, type: 'comment' }];
+
+  const match = line.match(/^(\s*(?:-\s+)?)([^:#][^:]*?)(\s*:)(.*)$/);
+  if (!match) return tokenizeScalar(line);
+
+  const [, prefix, key, separator, value] = match;
+  const commentIndex = value.indexOf('#');
+  const scalar = commentIndex === -1 ? value : value.slice(0, commentIndex);
+  const comment = commentIndex === -1 ? '' : value.slice(commentIndex);
+
+  return [
+    { value: prefix, type: 'plain' },
+    { value: key, type: 'key' },
+    { value: separator, type: 'punctuation' },
+    ...tokenizeScalar(scalar),
+    ...(comment ? [{ value: comment, type: 'comment' as const }] : []),
+  ];
+}
+
+function tokenizeTomlLine(line: string): ConfigToken[] {
+  if (line.trimStart().startsWith('#')) return [{ value: line, type: 'comment' }];
+
+  const table = line.match(/^(\s*)(\[\[?.+\]?\])(\s*)(#.*)?$/);
+  if (table) {
+    return [
+      { value: table[1], type: 'plain' },
+      { value: table[2], type: 'key' },
+      { value: table[3], type: 'plain' },
+      ...(table[4] ? [{ value: table[4], type: 'comment' as const }] : []),
+    ];
+  }
+
+  const match = line.match(/^(\s*)([^#=]+?)(\s*=)(.*)$/);
+  if (!match) return tokenizeScalar(line);
+
+  const [, prefix, key, separator, value] = match;
+  const commentIndex = value.indexOf('#');
+  const scalar = commentIndex === -1 ? value : value.slice(0, commentIndex);
+  const comment = commentIndex === -1 ? '' : value.slice(commentIndex);
+
+  return [
+    { value: prefix, type: 'plain' },
+    { value: key, type: 'key' },
+    { value: separator, type: 'punctuation' },
+    ...tokenizeScalar(scalar),
+    ...(comment ? [{ value: comment, type: 'comment' as const }] : []),
+  ];
+}
+
+export function tokenizeConfig(content: string, format: ExportFormat): ConfigToken[] {
+  switch (format) {
+    case 'json':
+      return tokenizeJson(content);
+    case 'yaml':
+      return tokenizeLines(content, tokenizeYamlLine);
+    case 'toml':
+      return tokenizeLines(content, tokenizeTomlLine);
+  }
+}


### PR DESCRIPTION
## Summary
- render exported JSON, YAML, and TOML with semantic syntax tokens
- add theme-aware token colors for light and dark modes
- cover tokenizer output with unit tests

## Validation
- `npm run lint`
- `npm run test:run`
- `npm run build`