### PR TITLE
Add secure Studio configuration handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Oh My Posh Visual Configurator project will be docume
 
 ## [2026-08-01]
 
+### Added
+
+- Added a secure, browser-only Studio handoff that imports JSON, YAML, or TOML configurations through a nonce-gated `postMessage` exchange without exposing configuration content in URLs or server storage.
+
 ### Changed: Compact Header Controls
 
 - Kept reset, settings, and theme actions icon-only below the desktop workspace breakpoint to preserve room for compact editing controls.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,11 +12,13 @@ import { ToastContainer, useToastStore } from './components/Toast';
 import { preloadSegments } from './utils/segmentLoader';
 import { useSavedConfigsStore, setupDraftAutoSave } from './store/savedConfigsStore';
 import { useMediaQuery } from './hooks/useMediaQuery';
+import { useStudioConfigHandoff } from './hooks/useStudioConfigHandoff';
 import { NerdIcon } from './components/NerdIcon';
 
 function App() {
   const showToast = useToastStore((state) => state.showToast);
   const initializedRef = useRef(false);
+  const [restorationComplete, setRestorationComplete] = useState(false);
   const [activeCompactPanel, setActiveCompactPanel] = useState<'segments' | 'canvas' | 'preview' | 'properties'>('canvas');
   const [segmentsCollapsed, setSegmentsCollapsed] = useState(false);
   const [propertiesCollapsed, setPropertiesCollapsed] = useState(false);
@@ -36,14 +38,16 @@ function App() {
       // Load saved configs from storage
       await useSavedConfigsStore.getState().loadFromStorage();
       
-      // Check if there's a last loaded config to restore
+      // Restore saved config state and load any draft before accepting a Studio handoff.
       const restoredConfigName = await useSavedConfigsStore.getState().autoRestoreLastConfig();
+      await useSavedConfigsStore.getState().loadDraft();
       if (restoredConfigName) {
         showToast(`Restored "${restoredConfigName}"`, 'info');
       }
       
       // Setup draft auto-save AFTER config is restored
       unsubscribe = setupDraftAutoSave();
+      setRestorationComplete(true);
     };
     
     initializeApp();
@@ -52,6 +56,8 @@ function App() {
       if (unsubscribe) unsubscribe();
     };
   }, [showToast]);
+
+  useStudioConfigHandoff(restorationComplete, showToast);
 
   return (
     <div className="flex flex-col h-screen bg-[#0f0f23]">

--- a/src/hooks/__tests__/useStudioConfigHandoff.test.tsx
+++ b/src/hooks/__tests__/useStudioConfigHandoff.test.tsx
@@ -1,0 +1,107 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useStudioConfigHandoff } from '../useStudioConfigHandoff';
+import {
+  STUDIO_CONFIG_NONCE_FRAGMENT_KEY,
+  STUDIO_CONFIG_PROTOCOL_VERSION,
+  STUDIO_ORIGIN,
+} from '../../utils/studioConfigProtocol';
+
+const handoffMocks = vi.hoisted(() => ({
+  importStudioConfig: vi.fn(),
+}));
+
+vi.mock('../../utils/studioConfigImport', () => ({
+  importStudioConfig: handoffMocks.importStudioConfig,
+}));
+
+const nonce = 'Q2hhdEdQVC1jb25maWd1cmF0b3ItaGFuZG9mZi0xMjM0NTY';
+
+function Harness({
+  restorationComplete,
+  showToast,
+}: {
+  restorationComplete: boolean;
+  showToast: (message: string, type: 'success' | 'error' | 'info') => void;
+}) {
+  useStudioConfigHandoff(restorationComplete, showToast);
+  return null;
+}
+
+describe('useStudioConfigHandoff', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let openerDescriptor: PropertyDescriptor | undefined;
+  let originalHash: string;
+
+  beforeEach(() => {
+    handoffMocks.importStudioConfig.mockReset();
+    handoffMocks.importStudioConfig.mockReturnValue([]);
+    openerDescriptor = Object.getOwnPropertyDescriptor(window, 'opener');
+    originalHash = window.location.hash;
+    window.location.hash = `${STUDIO_CONFIG_NONCE_FRAGMENT_KEY}=${nonce}`;
+    Object.defineProperty(window, 'opener', {
+      configurable: true,
+      value: window,
+    });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    if (openerDescriptor) {
+      Object.defineProperty(window, 'opener', openerDescriptor);
+    } else {
+      delete window.opener;
+    }
+    window.location.hash = originalHash;
+    vi.restoreAllMocks();
+  });
+
+  it('waits for restoration, posts readiness, imports once, and removes its listener', () => {
+    const showToast = vi.fn();
+    const postMessage = vi.spyOn(window, 'postMessage').mockImplementation(() => undefined);
+    const createImportEvent = () => new MessageEvent('message', {
+      origin: STUDIO_ORIGIN,
+      source: window,
+      data: {
+        type: 'omp-studio-config',
+        version: STUDIO_CONFIG_PROTOCOL_VERSION,
+        nonce,
+        format: 'json',
+        text: '{"blocks":[]}',
+      },
+    });
+
+    act(() => root.render(<Harness restorationComplete={false} showToast={showToast} />));
+    expect(postMessage).not.toHaveBeenCalled();
+
+    act(() => root.render(<Harness restorationComplete showToast={showToast} />));
+    expect(postMessage).toHaveBeenCalledWith(
+      {
+        type: 'omp-configurator-ready',
+        version: STUDIO_CONFIG_PROTOCOL_VERSION,
+        nonce,
+      },
+      STUDIO_ORIGIN
+    );
+
+    act(() => {
+      window.dispatchEvent(createImportEvent());
+      window.dispatchEvent(createImportEvent());
+    });
+    expect(handoffMocks.importStudioConfig).toHaveBeenCalledTimes(1);
+    expect(showToast).toHaveBeenCalledWith(
+      'Configuration imported from Oh My Posh Studio.',
+      'success'
+    );
+
+    act(() => root.unmount());
+    window.dispatchEvent(createImportEvent());
+    expect(handoffMocks.importStudioConfig).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useStudioConfigHandoff.ts
+++ b/src/hooks/useStudioConfigHandoff.ts
@@ -1,0 +1,59 @@
+import { useEffect, useRef } from 'react';
+import { importStudioConfig } from '../utils/studioConfigImport';
+import {
+  createStudioConfigHandoff,
+  getStudioConfigHandoffNonce,
+  STUDIO_ORIGIN,
+} from '../utils/studioConfigProtocol';
+
+type ShowToast = (message: string, type: 'success' | 'error' | 'info') => void;
+
+function importErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : 'Invalid configuration';
+}
+
+export function useStudioConfigHandoff(restorationComplete: boolean, showToast: ShowToast) {
+  const consumedNonceRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const opener = window.opener;
+    if (!restorationComplete || !opener) {
+      return;
+    }
+
+    const nonce = getStudioConfigHandoffNonce(window.location.hash);
+    if (!nonce || consumedNonceRef.current === nonce) {
+      return;
+    }
+
+    const handoff = createStudioConfigHandoff(nonce, opener);
+    const handleMessage = (event: MessageEvent<unknown>) => {
+      const message = handoff.receive(event);
+      if (!message) {
+        return;
+      }
+
+      consumedNonceRef.current = nonce;
+
+      try {
+        const enabledFeatures = importStudioConfig(message);
+        const featuresMessage = enabledFeatures.length > 0
+          ? ` Auto-enabled: ${enabledFeatures.join(', ')}.`
+          : '';
+        showToast(`Configuration imported from Oh My Posh Studio.${featuresMessage}`, 'success');
+      } catch (error) {
+        showToast(
+          `Unable to import the Studio configuration: ${importErrorMessage(error)}`,
+          'error'
+        );
+      }
+    };
+
+    window.addEventListener('message', handleMessage);
+    opener.postMessage(handoff.readyMessage, STUDIO_ORIGIN);
+
+    return () => {
+      window.removeEventListener('message', handleMessage);
+    };
+  }, [restorationComplete, showToast]);
+}

--- a/src/utils/__tests__/studioConfigHandoff.test.ts
+++ b/src/utils/__tests__/studioConfigHandoff.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { useAdvancedFeaturesStore } from '../../store/advancedFeaturesStore';
+import { useConfigStore } from '../../store/configStore';
+import { useSavedConfigsStore } from '../../store/savedConfigsStore';
+import { importStudioConfig } from '../studioConfigImport';
+import {
+  createStudioConfigHandoff,
+  getStudioConfigHandoffNonce,
+  STUDIO_CONFIG_NONCE_FRAGMENT_KEY,
+  STUDIO_CONFIG_PROTOCOL_VERSION,
+  STUDIO_ORIGIN,
+} from '../studioConfigProtocol';
+
+const nonce = 'Q2hhdEdQVC1jb25maWd1cmF0b3ItaGFuZG9mZi0xMjM0NTY';
+const initialFeatures = { ...useAdvancedFeaturesStore.getState().features };
+const clearLastLoadedId = useSavedConfigsStore.getState().clearLastLoadedId;
+
+function handoffEvent(
+  origin: string,
+  data: unknown,
+  source: MessageEventSource | null = window
+): Pick<MessageEvent<unknown>, 'data' | 'origin' | 'source'> {
+  return { origin, data, source };
+}
+
+function validMessage(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+  return {
+    type: 'omp-studio-config',
+    version: STUDIO_CONFIG_PROTOCOL_VERSION,
+    nonce,
+    format: 'json',
+    text: JSON.stringify({
+      blocks: [{
+        type: 'prompt',
+        segments: [{ type: 'text', alias: 'studio' }],
+      }],
+    }),
+    ...overrides,
+  };
+}
+
+describe('Studio Configurator handoff', () => {
+  beforeEach(() => {
+    useConfigStore.getState().resetConfig();
+    useConfigStore.setState({
+      selectedBlockId: null,
+      selectedSegmentId: null,
+      selectedTooltipId: null,
+      previewPaletteName: undefined,
+    });
+    useSavedConfigsStore.setState({
+      lastLoadedId: 'saved-config',
+      clearLastLoadedId: () => useSavedConfigsStore.setState({ lastLoadedId: null }),
+    });
+    useAdvancedFeaturesStore.setState({
+      features: { ...initialFeatures },
+      autoDetectOnImport: true,
+    });
+  });
+
+  afterEach(() => {
+    useSavedConfigsStore.setState({ clearLastLoadedId });
+  });
+
+  it('reads one valid base64url nonce from the expected hash parameter', () => {
+    expect(
+      getStudioConfigHandoffNonce(`#${STUDIO_CONFIG_NONCE_FRAGMENT_KEY}=${nonce}`)
+    ).toBe(nonce);
+  });
+
+  it('ignores missing, duplicate, and malformed hash nonce values', () => {
+    expect(getStudioConfigHandoffNonce('')).toBeNull();
+    expect(getStudioConfigHandoffNonce(`#${STUDIO_CONFIG_NONCE_FRAGMENT_KEY}=short`)).toBeNull();
+    expect(
+      getStudioConfigHandoffNonce(
+        `#${STUDIO_CONFIG_NONCE_FRAGMENT_KEY}=${nonce}&${STUDIO_CONFIG_NONCE_FRAGMENT_KEY}=${nonce}`
+      )
+    ).toBeNull();
+  });
+
+  it('sends the expected ready message and imports a valid Studio configuration once', () => {
+    const handoff = createStudioConfigHandoff(nonce, window);
+
+    expect(handoff.readyMessage).toEqual({
+      type: 'omp-configurator-ready',
+      version: STUDIO_CONFIG_PROTOCOL_VERSION,
+      nonce,
+    });
+
+    const message = handoff.receive(handoffEvent(STUDIO_ORIGIN, validMessage()));
+    expect(message).not.toBeNull();
+
+    const enabledFeatures = importStudioConfig(message!);
+
+    expect(useConfigStore.getState().config.blocks[0].segments[0].type).toBe('text');
+    expect(useConfigStore.getState().selectedBlockId).toBeNull();
+    expect(useSavedConfigsStore.getState().lastLoadedId).toBeNull();
+    expect(enabledFeatures).toContain('Template Alias');
+    expect(handoff.consumed).toBe(true);
+    expect(handoff.receive(handoffEvent(STUDIO_ORIGIN, validMessage()))).toBeNull();
+  });
+
+  it('does not accept a message from another origin', () => {
+    const handoff = createStudioConfigHandoff(nonce, window);
+
+    expect(handoff.receive(handoffEvent('https://example.com', validMessage()))).toBeNull();
+    expect(handoff.consumed).toBe(false);
+    expect(useConfigStore.getState().config.blocks[0].segments[0].type).toBe('path');
+  });
+
+  it('does not accept a message with a different nonce', () => {
+    const handoff = createStudioConfigHandoff(nonce, window);
+
+    expect(
+      handoff.receive(handoffEvent(STUDIO_ORIGIN, validMessage({ nonce: 'wrong-nonce' })))
+    ).toBeNull();
+    expect(handoff.consumed).toBe(false);
+  });
+
+  it('does not accept malformed payloads', () => {
+    const handoff = createStudioConfigHandoff(nonce, window);
+
+    expect(
+      handoff.receive(handoffEvent(STUDIO_ORIGIN, validMessage({ format: 'xml' })))
+    ).toBeNull();
+    expect(
+      handoff.receive(handoffEvent(STUDIO_ORIGIN, validMessage({ text: '' })))
+    ).toBeNull();
+    expect(
+      handoff.receive(handoffEvent(STUDIO_ORIGIN, {
+        type: 'omp-studio-config',
+        version: 2,
+        nonce,
+        format: 'json',
+        text: '{}',
+      }))
+    ).toBeNull();
+    expect(handoff.consumed).toBe(false);
+  });
+
+  it('does not accept a message from another window', () => {
+    const handoff = createStudioConfigHandoff(nonce, window);
+
+    expect(
+      handoff.receive(handoffEvent(STUDIO_ORIGIN, validMessage(), null))
+    ).toBeNull();
+    expect(handoff.consumed).toBe(false);
+  });
+
+  it('consumes a parser-invalid payload without allowing a later overwrite', () => {
+    const handoff = createStudioConfigHandoff(nonce, window);
+    const message = handoff.receive(
+      handoffEvent(STUDIO_ORIGIN, validMessage({ text: '{ invalid json' }))
+    );
+
+    expect(() => importStudioConfig(message!)).toThrow('Failed to parse JSON file');
+    expect(handoff.consumed).toBe(true);
+    expect(handoff.receive(handoffEvent(STUDIO_ORIGIN, validMessage()))).toBeNull();
+  });
+});

--- a/src/utils/studioConfigImport.ts
+++ b/src/utils/studioConfigImport.ts
@@ -1,0 +1,20 @@
+import { useAdvancedFeaturesStore } from '../store/advancedFeaturesStore';
+import { useConfigStore } from '../store/configStore';
+import { useSavedConfigsStore } from '../store/savedConfigsStore';
+import { importConfig } from './configImporter';
+import type { StudioConfigImportMessage } from './studioConfigProtocol';
+
+/**
+ * Imports a validated Studio payload using the same parser and post-import behavior as manual imports.
+ */
+export function importStudioConfig(message: StudioConfigImportMessage): string[] {
+  const config = importConfig(message.text, `studio-config.${message.format}`);
+
+  const configStore = useConfigStore.getState();
+  configStore.setConfig(config);
+  configStore.selectBlock(null);
+  configStore.setPreviewPaletteName(undefined);
+  useSavedConfigsStore.getState().clearLastLoadedId();
+
+  return useAdvancedFeaturesStore.getState().detectAndEnableFeatures(config);
+}

--- a/src/utils/studioConfigProtocol.ts
+++ b/src/utils/studioConfigProtocol.ts
@@ -1,0 +1,112 @@
+export const STUDIO_ORIGIN = 'https://ohmyposh.dev';
+export const STUDIO_CONFIG_PROTOCOL_VERSION = 1;
+export const STUDIO_CONFIG_NONCE_FRAGMENT_KEY = 'omp-configurator-nonce';
+
+export type StudioConfigFormat = 'json' | 'yaml' | 'toml';
+
+export interface StudioConfigReadyMessage {
+  type: 'omp-configurator-ready';
+  version: typeof STUDIO_CONFIG_PROTOCOL_VERSION;
+  nonce: string;
+}
+
+export interface StudioConfigImportMessage {
+  type: 'omp-studio-config';
+  version: typeof STUDIO_CONFIG_PROTOCOL_VERSION;
+  nonce: string;
+  format: StudioConfigFormat;
+  text: string;
+}
+
+type StudioConfigHandoffEvent = Pick<MessageEvent<unknown>, 'data' | 'origin' | 'source'>;
+
+const noncePattern = /^[A-Za-z0-9_-]{43,128}$/;
+const formats = new Set<string>(['json', 'yaml', 'toml']);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isStudioConfigFormat(value: unknown): value is StudioConfigFormat {
+  return typeof value === 'string' && formats.has(value);
+}
+
+/**
+ * Returns the single URL fragment nonce used by a Studio handoff.
+ */
+export function getStudioConfigHandoffNonce(hash: string): string | null {
+  if (!hash.startsWith('#')) {
+    return null;
+  }
+
+  const parameters = new URLSearchParams(hash.slice(1));
+  const nonces = parameters.getAll(STUDIO_CONFIG_NONCE_FRAGMENT_KEY);
+  if (nonces.length !== 1 || !noncePattern.test(nonces[0])) {
+    return null;
+  }
+
+  return nonces[0];
+}
+
+export function createStudioConfigReadyMessage(nonce: string): StudioConfigReadyMessage {
+  return {
+    type: 'omp-configurator-ready',
+    version: STUDIO_CONFIG_PROTOCOL_VERSION,
+    nonce,
+  };
+}
+
+function parseStudioConfigImportMessage(
+  data: unknown,
+  nonce: string
+): StudioConfigImportMessage | null {
+  if (!isRecord(data)) {
+    return null;
+  }
+
+  if (
+    data.type !== 'omp-studio-config' ||
+    data.version !== STUDIO_CONFIG_PROTOCOL_VERSION ||
+    data.nonce !== nonce ||
+    !isStudioConfigFormat(data.format) ||
+    typeof data.text !== 'string' ||
+    data.text.length === 0
+  ) {
+    return null;
+  }
+
+  return {
+    type: data.type,
+    version: data.version,
+    nonce: data.nonce,
+    format: data.format,
+    text: data.text,
+  };
+}
+
+/**
+ * Accepts exactly one valid import message after the Configurator signals readiness.
+ */
+export function createStudioConfigHandoff(nonce: string, opener: MessageEventSource) {
+  let consumed = false;
+
+  return {
+    readyMessage: createStudioConfigReadyMessage(nonce),
+    get consumed(): boolean {
+      return consumed;
+    },
+    receive(event: StudioConfigHandoffEvent): StudioConfigImportMessage | null {
+      if (consumed || event.origin !== STUDIO_ORIGIN || event.source !== opener) {
+        return null;
+      }
+
+      const message = parseStudioConfigImportMessage(event.data, nonce);
+      if (!message) {
+        return null;
+      }
+
+      consumed = true;
+      return message;
+    },
+  };
+}


### PR DESCRIPTION
Adds a nonce-gated, browser-only postMessage exchange from Studio to Configurator. The handoff never puts configuration content in URLs or server storage, validates origin/payload/version/format, imports once after persisted-state restoration, and includes focused protocol/import tests.