### PR TITLE
Add Studio nonce compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Oh My Posh Visual Configurator project will be documented in this file.
 
+## [2026-08-02]
+
+### Fixed
+
+- Accepted Studio's legacy `#nonce=` fragment alias for secure configuration handoffs while rejecting duplicate or ambiguous nonce parameters.
+
 ## [2026-08-01]
 
 ### Added

--- a/src/utils/__tests__/studioConfigHandoff.test.ts
+++ b/src/utils/__tests__/studioConfigHandoff.test.ts
@@ -12,6 +12,7 @@ import {
 } from '../studioConfigProtocol';
 
 const nonce = 'Q2hhdEdQVC1jb25maWd1cmF0b3ItaGFuZG9mZi0xMjM0NTY';
+const legacyNonce = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
 const initialFeatures = { ...useAdvancedFeaturesStore.getState().features };
 const clearLastLoadedId = useSavedConfigsStore.getState().clearLastLoadedId;
 
@@ -62,18 +63,28 @@ describe('Studio Configurator handoff', () => {
     useSavedConfigsStore.setState({ clearLastLoadedId });
   });
 
-  it('reads one valid base64url nonce from the expected hash parameter', () => {
+  it('reads one valid nonce from the canonical hash parameter', () => {
     expect(
       getStudioConfigHandoffNonce(`#${STUDIO_CONFIG_NONCE_FRAGMENT_KEY}=${nonce}`)
     ).toBe(nonce);
   });
 
-  it('ignores missing, duplicate, and malformed hash nonce values', () => {
+  it('reads one valid nonce from the legacy hash parameter', () => {
+    expect(getStudioConfigHandoffNonce(`#nonce=${legacyNonce}`)).toBe(legacyNonce);
+  });
+
+  it('rejects missing, duplicate, malformed, and ambiguous hash nonce values', () => {
     expect(getStudioConfigHandoffNonce('')).toBeNull();
     expect(getStudioConfigHandoffNonce(`#${STUDIO_CONFIG_NONCE_FRAGMENT_KEY}=short`)).toBeNull();
     expect(
       getStudioConfigHandoffNonce(
         `#${STUDIO_CONFIG_NONCE_FRAGMENT_KEY}=${nonce}&${STUDIO_CONFIG_NONCE_FRAGMENT_KEY}=${nonce}`
+      )
+    ).toBeNull();
+    expect(getStudioConfigHandoffNonce(`#nonce=${legacyNonce}&nonce=${legacyNonce}`)).toBeNull();
+    expect(
+      getStudioConfigHandoffNonce(
+        `#${STUDIO_CONFIG_NONCE_FRAGMENT_KEY}=${nonce}&nonce=${legacyNonce}`
       )
     ).toBeNull();
   });

--- a/src/utils/studioConfigProtocol.ts
+++ b/src/utils/studioConfigProtocol.ts
@@ -1,6 +1,7 @@
 export const STUDIO_ORIGIN = 'https://ohmyposh.dev';
 export const STUDIO_CONFIG_PROTOCOL_VERSION = 1;
 export const STUDIO_CONFIG_NONCE_FRAGMENT_KEY = 'omp-configurator-nonce';
+const legacyStudioConfigNonceFragmentKey = 'nonce';
 
 export type StudioConfigFormat = 'json' | 'yaml' | 'toml';
 
@@ -40,12 +41,18 @@ export function getStudioConfigHandoffNonce(hash: string): string | null {
   }
 
   const parameters = new URLSearchParams(hash.slice(1));
-  const nonces = parameters.getAll(STUDIO_CONFIG_NONCE_FRAGMENT_KEY);
-  if (nonces.length !== 1 || !noncePattern.test(nonces[0])) {
+  const canonicalNonces = parameters.getAll(STUDIO_CONFIG_NONCE_FRAGMENT_KEY);
+  const legacyNonces = parameters.getAll(legacyStudioConfigNonceFragmentKey);
+  if (
+    canonicalNonces.length > 1 ||
+    legacyNonces.length > 1 ||
+    (canonicalNonces.length === 1 && legacyNonces.length === 1)
+  ) {
     return null;
   }
 
-  return nonces[0];
+  const nonce = canonicalNonces[0] ?? legacyNonces[0];
+  return nonce !== undefined && noncePattern.test(nonce) ? nonce : null;
 }
 
 export function createStudioConfigReadyMessage(nonce: string): StudioConfigReadyMessage {


### PR DESCRIPTION
Adds backwards-compatible support for Studio handoffs using the legacy `#nonce=` URL fragment alias while preserving the canonical `#omp-configurator-nonce=` key. Rejects duplicate nonce parameters and any fragment containing both recognized keys to prevent ambiguity.