### PR TITLE
Restore Studio runtime on return visits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to the Oh My Posh Visual Configurator project will be docume
 
 - Accepted Studio's legacy `#nonce=` fragment alias for secure configuration handoffs while rejecting duplicate or ambiguous nonce parameters.
 
+### Changed
+
+- Remember Studio WebAssembly initialization approval and automatically restore the real preview on later visits, using the browser's cached runtime when available.
+
 ## [2026-08-01]
 
 ### Added

--- a/src/components/PreviewPanel/StudioPreview.tsx
+++ b/src/components/PreviewPanel/StudioPreview.tsx
@@ -24,13 +24,16 @@ function getStudioColumns(availableWidth: number): number {
 export function StudioPreview({ backgroundColor, textColor, active }: StudioPreviewProps) {
   const config = useConfigStore((state) => state.config);
   const setPreviewRenderer = useConfigStore((state) => state.setPreviewRenderer);
+  const studioRuntimeEnabled = useConfigStore((state) => state.studioRuntimeEnabled);
+  const enableStudioRuntime = useConfigStore((state) => state.enableStudioRuntime);
   const previewRef = useRef<HTMLDivElement>(null);
   const [columns, setColumns] = useState(DEFAULT_STUDIO_COLUMNS);
   const { status, progress, svg, error, initialize } = useStudioRenderer(
     config,
     backgroundColor,
     active,
-    columns
+    columns,
+    active && studioRuntimeEnabled
   );
 
   useEffect(() => {
@@ -63,7 +66,10 @@ export function StudioPreview({ backgroundColor, textColor, active }: StudioPrev
             <div className="mt-4 flex flex-wrap items-center gap-3">
               <button
                 type="button"
-                onClick={initialize}
+                onClick={() => {
+                  enableStudioRuntime();
+                  initialize();
+                }}
                 className="px-3 py-2 rounded-md bg-[#e94560] text-white text-xs font-semibold hover:bg-[#ff5874] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#e94560] transition-colors"
               >
                 Initialize Studio
@@ -77,7 +83,7 @@ export function StudioPreview({ backgroundColor, textColor, active }: StudioPrev
               </button>
             </div>
             <p className="mt-3 text-[11px] text-gray-500">
-              You will be asked to initialize Studio again after reloading the page.
+              Studio will load automatically on future visits after you initialize it.
             </p>
           </div>
         </div>

--- a/src/hooks/__tests__/useStudioRenderer.test.tsx
+++ b/src/hooks/__tests__/useStudioRenderer.test.tsx
@@ -6,19 +6,25 @@ import { useStudioRenderer } from '../useStudioRenderer';
 
 const studioMocks = vi.hoisted(() => ({
   render: vi.fn(),
+  loadStudioRuntime: vi.fn(),
 }));
 
 vi.mock('../../utils/studioLoader', () => ({
   getLoadedStudioRuntime: () => null,
   subscribeToStudioRuntime: () => () => undefined,
-  loadStudioRuntime: async () => ({
-    render: studioMocks.render,
-    dataJson: '{}',
-  }),
+  loadStudioRuntime: studioMocks.loadStudioRuntime,
 }));
 
-function Harness({ config, columns = 120 }: { config: OhMyPoshConfig; columns?: number }) {
-  const result = useStudioRenderer(config, '#1e1e1e', true, columns);
+function Harness({
+  config,
+  columns = 120,
+  autoInitialize = false,
+}: {
+  config: OhMyPoshConfig;
+  columns?: number;
+  autoInitialize?: boolean;
+}) {
+  const result = useStudioRenderer(config, '#1e1e1e', true, columns, autoInitialize);
   return (
     <div>
       <button type="button" onClick={result.initialize}>
@@ -38,6 +44,11 @@ describe('useStudioRenderer', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     studioMocks.render.mockReset();
+    studioMocks.loadStudioRuntime.mockReset();
+    studioMocks.loadStudioRuntime.mockResolvedValue({
+      render: studioMocks.render,
+      dataJson: '{}',
+    });
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
@@ -110,5 +121,20 @@ describe('useStudioRenderer', () => {
       '{}',
       expect.objectContaining({ columns: 64 })
     );
+  });
+
+  it('initializes automatically when Studio was enabled previously', async () => {
+    const config: OhMyPoshConfig = {
+      version: 4,
+      blocks: [],
+    };
+
+    act(() => root.render(<Harness config={config} autoInitialize />));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(studioMocks.loadStudioRuntime).toHaveBeenCalledOnce();
+    expect(container.querySelector('[data-testid="status"]')?.textContent).toBe('ready');
   });
 });

--- a/src/hooks/useStudioRenderer.ts
+++ b/src/hooks/useStudioRenderer.ts
@@ -35,7 +35,8 @@ export function useStudioRenderer(
   config: OhMyPoshConfig,
   backgroundColor: string,
   active = true,
-  columns = 120
+  columns = 120,
+  autoInitialize = false
 ): UseStudioRendererResult {
   const initialRuntime = getLoadedStudioRuntime();
   const [status, setStatus] = useState<StudioStatus>(initialRuntime ? 'ready' : 'idle');
@@ -87,6 +88,13 @@ export function useStudioRenderer(
         setStatus('error');
       });
   }, []);
+
+  useEffect(() => {
+    if (!autoInitialize || status !== 'idle') return;
+
+    const timeout = window.setTimeout(initialize, 0);
+    return () => window.clearTimeout(timeout);
+  }, [autoInitialize, initialize, status]);
 
   useEffect(() => {
     if (!active || status !== 'ready' || !renderRef.current) return;

--- a/src/store/__tests__/configStore.test.ts
+++ b/src/store/__tests__/configStore.test.ts
@@ -69,6 +69,14 @@ describe('configStore', () => {
 
         expect(useConfigStore.getState().previewRenderer).toBe('legacy');
       });
+
+      it('remembers when Studio has been enabled', () => {
+        useConfigStore.setState({ studioRuntimeEnabled: false });
+
+        useConfigStore.getState().enableStudioRuntime();
+
+        expect(useConfigStore.getState().studioRuntimeEnabled).toBe(true);
+      });
     });
 
     it('should clear selections', () => {

--- a/src/store/configStore.ts
+++ b/src/store/configStore.ts
@@ -15,6 +15,7 @@ interface ConfigState {
   previewBackground: 'dark' | 'light';
   previewRenderer: 'studio' | 'legacy';
   previewPaletteName: string | undefined;
+  studioRuntimeEnabled: boolean;
 
   // Actions
   setConfig: (config: OhMyPoshConfig) => void;
@@ -69,6 +70,7 @@ interface ConfigState {
   // Preview
   setPreviewBackground: (bg: 'dark' | 'light') => void;
   setPreviewRenderer: (renderer: 'studio' | 'legacy') => void;
+  enableStudioRuntime: () => void;
 }
 
 const defaultConfig: OhMyPoshConfig = {
@@ -123,6 +125,7 @@ export const useConfigStore = create<ConfigState>()(
       previewBackground: 'dark',
       previewRenderer: 'studio',
       previewPaletteName: undefined,
+      studioRuntimeEnabled: false,
 
       setConfig: (config) => set({ config }),
 
@@ -515,6 +518,7 @@ export const useConfigStore = create<ConfigState>()(
 
       setPreviewBackground: (bg) => set({ previewBackground: bg }),
       setPreviewRenderer: (renderer) => set({ previewRenderer: renderer }),
+      enableStudioRuntime: () => set({ studioRuntimeEnabled: true }),
     }),
     {
       name: 'ohmyposh-config',
@@ -523,6 +527,7 @@ export const useConfigStore = create<ConfigState>()(
         exportFormat: state.exportFormat,
         previewBackground: state.previewBackground,
         previewRenderer: state.previewRenderer,
+        studioRuntimeEnabled: state.studioRuntimeEnabled,
       }),
     }
   )


### PR DESCRIPTION
After a user initializes the real Studio preview, returning visits still require another manual click even when the browser retains the Wasm runtime.

Persist the user's explicit Studio approval and automatically initialize the renderer when Studio is active on later visits. First use remains opt-in; the browser serves the existing self-hosted assets from its HTTP cache when available.

Tests: `npm run lint`, `npm run test:run`, `npm run validate`, and `npm run build`.