### PR TITLE
Fix theme preview font rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Oh My Posh Visual Configurator project will be docume
 ### Fixed
 
 - Replaced retired official-theme images with server-generated SVG previews for official, sample, and community configurations.
+- Render generated previews inline so they inherit the bundled Victor Mono Nerd Font and preserve prompt icons.
 - Accepted Studio's legacy `#nonce=` fragment alias for secure configuration handoffs while rejecting duplicate or ambiguous nonce parameters.
 
 ### Changed

--- a/public/configs/community/previews/cinnamon-1_shell.svg
+++ b/public/configs/community/previews/cinnamon-1_shell.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/community/previews/dotnet-azure-developer.svg
+++ b/public/configs/community/previews/dotnet-azure-developer.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/manifest.json
+++ b/public/configs/official/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "lastUpdated": "2026-08-02T18:10:59.109Z",
+  "lastUpdated": "2026-08-02T18:17:14.234Z",
   "themes": [
     {
       "name": "1_shell",

--- a/public/configs/official/previews/1_shell.svg
+++ b/public/configs/official/previews/1_shell.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/M365Princess.svg
+++ b/public/configs/official/previews/M365Princess.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/agnoster.minimal.svg
+++ b/public/configs/official/previews/agnoster.minimal.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/agnoster.svg
+++ b/public/configs/official/previews/agnoster.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/agnosterplus.svg
+++ b/public/configs/official/previews/agnosterplus.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/aliens.svg
+++ b/public/configs/official/previews/aliens.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/amro.svg
+++ b/public/configs/official/previews/amro.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 162.88 A 4,4 0 0 1 726.24,166.88 H 4 A 4,4 0 0 1 0,162.88 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="165.88" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/atomic.svg
+++ b/public/configs/official/previews/atomic.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="248.05" viewBox="0 0 730.24 248.05" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="248.05" viewBox="0 0 730.24 248.05" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 244.05 A 4,4 0 0 1 726.24,248.05 H 4 A 4,4 0 0 1 0,244.05 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="247.05" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/atomicBit.svg
+++ b/public/configs/official/previews/atomicBit.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="220.99" viewBox="0 0 730.24 220.99" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="220.99" viewBox="0 0 730.24 220.99" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 216.99 A 4,4 0 0 1 726.24,220.99 H 4 A 4,4 0 0 1 0,216.99 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="219.99" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/avit.svg
+++ b/public/configs/official/previews/avit.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 162.88 A 4,4 0 0 1 726.24,166.88 H 4 A 4,4 0 0 1 0,162.88 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="165.88" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/blue-owl.svg
+++ b/public/configs/official/previews/blue-owl.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/blueish.svg
+++ b/public/configs/official/previews/blueish.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/bubbles.svg
+++ b/public/configs/official/previews/bubbles.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/bubblesextra.svg
+++ b/public/configs/official/previews/bubblesextra.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/bubblesline.svg
+++ b/public/configs/official/previews/bubblesline.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/capr4n.svg
+++ b/public/configs/official/previews/capr4n.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/catppuccin.svg
+++ b/public/configs/official/previews/catppuccin.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/catppuccin_frappe.svg
+++ b/public/configs/official/previews/catppuccin_frappe.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/catppuccin_latte.svg
+++ b/public/configs/official/previews/catppuccin_latte.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/catppuccin_macchiato.svg
+++ b/public/configs/official/previews/catppuccin_macchiato.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/catppuccin_mocha.svg
+++ b/public/configs/official/previews/catppuccin_mocha.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/cert.svg
+++ b/public/configs/official/previews/cert.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/chips.svg
+++ b/public/configs/official/previews/chips.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="220.99" viewBox="0 0 730.24 220.99" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="220.99" viewBox="0 0 730.24 220.99" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 216.99 A 4,4 0 0 1 726.24,220.99 H 4 A 4,4 0 0 1 0,216.99 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="219.99" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/cinnamon.svg
+++ b/public/configs/official/previews/cinnamon.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/clean-detailed.svg
+++ b/public/configs/official/previews/clean-detailed.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="220.99" viewBox="0 0 730.24 220.99" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="220.99" viewBox="0 0 730.24 220.99" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 216.99 A 4,4 0 0 1 726.24,220.99 H 4 A 4,4 0 0 1 0,216.99 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="219.99" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/cloud-context.svg
+++ b/public/configs/official/previews/cloud-context.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="248.05" viewBox="0 0 730.24 248.05" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="248.05" viewBox="0 0 730.24 248.05" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 244.05 A 4,4 0 0 1 726.24,248.05 H 4 A 4,4 0 0 1 0,244.05 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="247.05" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/cloud-native-azure.svg
+++ b/public/configs/official/previews/cloud-native-azure.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="248.05" viewBox="0 0 730.24 248.05" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="248.05" viewBox="0 0 730.24 248.05" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 244.05 A 4,4 0 0 1 726.24,248.05 H 4 A 4,4 0 0 1 0,244.05 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="247.05" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/cobalt2.svg
+++ b/public/configs/official/previews/cobalt2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/craver.svg
+++ b/public/configs/official/previews/craver.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 162.88 A 4,4 0 0 1 726.24,166.88 H 4 A 4,4 0 0 1 0,162.88 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="165.88" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/darkblood.svg
+++ b/public/configs/official/previews/darkblood.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 162.88 A 4,4 0 0 1 726.24,166.88 H 4 A 4,4 0 0 1 0,162.88 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="165.88" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/devious-diamonds.svg
+++ b/public/configs/official/previews/devious-diamonds.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="275.1" viewBox="0 0 730.24 275.1" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="275.1" viewBox="0 0 730.24 275.1" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 271.1 A 4,4 0 0 1 726.24,275.1 H 4 A 4,4 0 0 1 0,271.1 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="274.1" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/di4am0nd.svg
+++ b/public/configs/official/previews/di4am0nd.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/dracula.svg
+++ b/public/configs/official/previews/dracula.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/easy-term.svg
+++ b/public/configs/official/previews/easy-term.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="220.99" viewBox="0 0 730.24 220.99" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="220.99" viewBox="0 0 730.24 220.99" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 216.99 A 4,4 0 0 1 726.24,220.99 H 4 A 4,4 0 0 1 0,216.99 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="219.99" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/emodipt-extend.svg
+++ b/public/configs/official/previews/emodipt-extend.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="220.99" viewBox="0 0 730.24 220.99" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="220.99" viewBox="0 0 730.24 220.99" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 216.99 A 4,4 0 0 1 726.24,220.99 H 4 A 4,4 0 0 1 0,216.99 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="219.99" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/emodipt.svg
+++ b/public/configs/official/previews/emodipt.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/fish.svg
+++ b/public/configs/official/previews/fish.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/free-ukraine.svg
+++ b/public/configs/official/previews/free-ukraine.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/froczh.svg
+++ b/public/configs/official/previews/froczh.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/glowsticks.svg
+++ b/public/configs/official/previews/glowsticks.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/gmay.svg
+++ b/public/configs/official/previews/gmay.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 162.88 A 4,4 0 0 1 726.24,166.88 H 4 A 4,4 0 0 1 0,162.88 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="165.88" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/grandpa-style.svg
+++ b/public/configs/official/previews/grandpa-style.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/gruvbox.svg
+++ b/public/configs/official/previews/gruvbox.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 162.88 A 4,4 0 0 1 726.24,166.88 H 4 A 4,4 0 0 1 0,162.88 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="165.88" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/half-life.svg
+++ b/public/configs/official/previews/half-life.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/honukai.svg
+++ b/public/configs/official/previews/honukai.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 162.88 A 4,4 0 0 1 726.24,166.88 H 4 A 4,4 0 0 1 0,162.88 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="165.88" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/hotstick.minimal.svg
+++ b/public/configs/official/previews/hotstick.minimal.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/hul10.svg
+++ b/public/configs/official/previews/hul10.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="220.99" viewBox="0 0 730.24 220.99" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="220.99" viewBox="0 0 730.24 220.99" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 216.99 A 4,4 0 0 1 726.24,220.99 H 4 A 4,4 0 0 1 0,216.99 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="219.99" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/hunk.svg
+++ b/public/configs/official/previews/hunk.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/huvix.svg
+++ b/public/configs/official/previews/huvix.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 162.88 A 4,4 0 0 1 726.24,166.88 H 4 A 4,4 0 0 1 0,162.88 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="165.88" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/if_tea.svg
+++ b/public/configs/official/previews/if_tea.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="220.99" viewBox="0 0 730.24 220.99" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="220.99" viewBox="0 0 730.24 220.99" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 216.99 A 4,4 0 0 1 726.24,220.99 H 4 A 4,4 0 0 1 0,216.99 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="219.99" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/illusi0n.svg
+++ b/public/configs/official/previews/illusi0n.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/iterm2.svg
+++ b/public/configs/official/previews/iterm2.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/jandedobbeleer.svg
+++ b/public/configs/official/previews/jandedobbeleer.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/jblab_2021.svg
+++ b/public/configs/official/previews/jblab_2021.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/jonnychipz.svg
+++ b/public/configs/official/previews/jonnychipz.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 162.88 A 4,4 0 0 1 726.24,166.88 H 4 A 4,4 0 0 1 0,162.88 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="165.88" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/json.svg
+++ b/public/configs/official/previews/json.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 162.88 A 4,4 0 0 1 726.24,166.88 H 4 A 4,4 0 0 1 0,162.88 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="165.88" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/jtracey93.svg
+++ b/public/configs/official/previews/jtracey93.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/jv_sitecorian.svg
+++ b/public/configs/official/previews/jv_sitecorian.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 162.88 A 4,4 0 0 1 726.24,166.88 H 4 A 4,4 0 0 1 0,162.88 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="165.88" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/kali.svg
+++ b/public/configs/official/previews/kali.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 162.88 A 4,4 0 0 1 726.24,166.88 H 4 A 4,4 0 0 1 0,162.88 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="165.88" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/kushal.svg
+++ b/public/configs/official/previews/kushal.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="220.99" viewBox="0 0 730.24 220.99" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="220.99" viewBox="0 0 730.24 220.99" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 216.99 A 4,4 0 0 1 726.24,220.99 H 4 A 4,4 0 0 1 0,216.99 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="219.99" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/lambda.svg
+++ b/public/configs/official/previews/lambda.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/lambdageneration.svg
+++ b/public/configs/official/previews/lambdageneration.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/larserikfinholt.svg
+++ b/public/configs/official/previews/larserikfinholt.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 162.88 A 4,4 0 0 1 726.24,166.88 H 4 A 4,4 0 0 1 0,162.88 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="165.88" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/lightgreen.svg
+++ b/public/configs/official/previews/lightgreen.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 162.88 A 4,4 0 0 1 726.24,166.88 H 4 A 4,4 0 0 1 0,162.88 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="165.88" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/marcduiker.svg
+++ b/public/configs/official/previews/marcduiker.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/markbull.svg
+++ b/public/configs/official/previews/markbull.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/material.svg
+++ b/public/configs/official/previews/material.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/microverse-power.svg
+++ b/public/configs/official/previews/microverse-power.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 162.88 A 4,4 0 0 1 726.24,166.88 H 4 A 4,4 0 0 1 0,162.88 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="165.88" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/mojada.svg
+++ b/public/configs/official/previews/mojada.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/montys.svg
+++ b/public/configs/official/previews/montys.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/mt.svg
+++ b/public/configs/official/previews/mt.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/multiverse-neon.svg
+++ b/public/configs/official/previews/multiverse-neon.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 162.88 A 4,4 0 0 1 726.24,166.88 H 4 A 4,4 0 0 1 0,162.88 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="165.88" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/negligible.svg
+++ b/public/configs/official/previews/negligible.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/neko.svg
+++ b/public/configs/official/previews/neko.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/night-owl.svg
+++ b/public/configs/official/previews/night-owl.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="329.21" viewBox="0 0 730.24 329.21" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="329.21" viewBox="0 0 730.24 329.21" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 325.21 A 4,4 0 0 1 726.24,329.21 H 4 A 4,4 0 0 1 0,325.21 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="328.21" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/nordtron.svg
+++ b/public/configs/official/previews/nordtron.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/nu4a.svg
+++ b/public/configs/official/previews/nu4a.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/onehalf.minimal.svg
+++ b/public/configs/official/previews/onehalf.minimal.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/paradox.svg
+++ b/public/configs/official/previews/paradox.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 162.88 A 4,4 0 0 1 726.24,166.88 H 4 A 4,4 0 0 1 0,162.88 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="165.88" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/pararussel.svg
+++ b/public/configs/official/previews/pararussel.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 162.88 A 4,4 0 0 1 726.24,166.88 H 4 A 4,4 0 0 1 0,162.88 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="165.88" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/patriksvensson.svg
+++ b/public/configs/official/previews/patriksvensson.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/peru.svg
+++ b/public/configs/official/previews/peru.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/pixelrobots.svg
+++ b/public/configs/official/previews/pixelrobots.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/plague.svg
+++ b/public/configs/official/previews/plague.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 162.88 A 4,4 0 0 1 726.24,166.88 H 4 A 4,4 0 0 1 0,162.88 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="165.88" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/poshmon.svg
+++ b/public/configs/official/previews/poshmon.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/powerlevel10k_classic.svg
+++ b/public/configs/official/previews/powerlevel10k_classic.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 162.88 A 4,4 0 0 1 726.24,166.88 H 4 A 4,4 0 0 1 0,162.88 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="165.88" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/powerlevel10k_lean.svg
+++ b/public/configs/official/previews/powerlevel10k_lean.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/powerlevel10k_modern.svg
+++ b/public/configs/official/previews/powerlevel10k_modern.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 162.88 A 4,4 0 0 1 726.24,166.88 H 4 A 4,4 0 0 1 0,162.88 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="165.88" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/powerlevel10k_rainbow.svg
+++ b/public/configs/official/previews/powerlevel10k_rainbow.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="220.99" viewBox="0 0 730.24 220.99" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="220.99" viewBox="0 0 730.24 220.99" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 216.99 A 4,4 0 0 1 726.24,220.99 H 4 A 4,4 0 0 1 0,216.99 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="219.99" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/powerline.svg
+++ b/public/configs/official/previews/powerline.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/probua.minimal.svg
+++ b/public/configs/official/previews/probua.minimal.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 162.88 A 4,4 0 0 1 726.24,166.88 H 4 A 4,4 0 0 1 0,162.88 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="165.88" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/pure.svg
+++ b/public/configs/official/previews/pure.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 162.88 A 4,4 0 0 1 726.24,166.88 H 4 A 4,4 0 0 1 0,162.88 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="165.88" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/quick-term.svg
+++ b/public/configs/official/previews/quick-term.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/remk.svg
+++ b/public/configs/official/previews/remk.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/robbyrussell.svg
+++ b/public/configs/official/previews/robbyrussell.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/rudolfs-dark.svg
+++ b/public/configs/official/previews/rudolfs-dark.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/rudolfs-light.svg
+++ b/public/configs/official/previews/rudolfs-light.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/sim-web.svg
+++ b/public/configs/official/previews/sim-web.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/slim.svg
+++ b/public/configs/official/previews/slim.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/slimfat.svg
+++ b/public/configs/official/previews/slimfat.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/smoothie.svg
+++ b/public/configs/official/previews/smoothie.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="220.99" viewBox="0 0 730.24 220.99" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="220.99" viewBox="0 0 730.24 220.99" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 216.99 A 4,4 0 0 1 726.24,220.99 H 4 A 4,4 0 0 1 0,216.99 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="219.99" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/sonicboom_dark.svg
+++ b/public/configs/official/previews/sonicboom_dark.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/sonicboom_light.svg
+++ b/public/configs/official/previews/sonicboom_light.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/sorin.svg
+++ b/public/configs/official/previews/sorin.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/space.svg
+++ b/public/configs/official/previews/space.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 162.88 A 4,4 0 0 1 726.24,166.88 H 4 A 4,4 0 0 1 0,162.88 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="165.88" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/spaceship.svg
+++ b/public/configs/official/previews/spaceship.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 162.88 A 4,4 0 0 1 726.24,166.88 H 4 A 4,4 0 0 1 0,162.88 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="165.88" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/star.svg
+++ b/public/configs/official/previews/star.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 162.88 A 4,4 0 0 1 726.24,166.88 H 4 A 4,4 0 0 1 0,162.88 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="165.88" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/stelbent-compact.minimal.svg
+++ b/public/configs/official/previews/stelbent-compact.minimal.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="220.99" viewBox="0 0 730.24 220.99" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="220.99" viewBox="0 0 730.24 220.99" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 216.99 A 4,4 0 0 1 726.24,220.99 H 4 A 4,4 0 0 1 0,216.99 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="219.99" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/stelbent.minimal.svg
+++ b/public/configs/official/previews/stelbent.minimal.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="220.99" viewBox="0 0 730.24 220.99" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="220.99" viewBox="0 0 730.24 220.99" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 216.99 A 4,4 0 0 1 726.24,220.99 H 4 A 4,4 0 0 1 0,216.99 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="219.99" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/takuya.svg
+++ b/public/configs/official/previews/takuya.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 162.88 A 4,4 0 0 1 726.24,166.88 H 4 A 4,4 0 0 1 0,162.88 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="165.88" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/the-unnamed.svg
+++ b/public/configs/official/previews/the-unnamed.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/thecyberden.svg
+++ b/public/configs/official/previews/thecyberden.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 162.88 A 4,4 0 0 1 726.24,166.88 H 4 A 4,4 0 0 1 0,162.88 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="165.88" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/tiwahu.svg
+++ b/public/configs/official/previews/tiwahu.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="275.1" viewBox="0 0 730.24 275.1" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="275.1" viewBox="0 0 730.24 275.1" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 271.1 A 4,4 0 0 1 726.24,275.1 H 4 A 4,4 0 0 1 0,271.1 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="274.1" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/tokyo.svg
+++ b/public/configs/official/previews/tokyo.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="275.1" viewBox="0 0 730.24 275.1" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="275.1" viewBox="0 0 730.24 275.1" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 271.1 A 4,4 0 0 1 726.24,275.1 H 4 A 4,4 0 0 1 0,271.1 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="274.1" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/tokyonight_storm.svg
+++ b/public/configs/official/previews/tokyonight_storm.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 162.88 A 4,4 0 0 1 726.24,166.88 H 4 A 4,4 0 0 1 0,162.88 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="165.88" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/tonybaloney.svg
+++ b/public/configs/official/previews/tonybaloney.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/uew.svg
+++ b/public/configs/official/previews/uew.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/unicorn.svg
+++ b/public/configs/official/previews/unicorn.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 162.88 A 4,4 0 0 1 726.24,166.88 H 4 A 4,4 0 0 1 0,162.88 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="165.88" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/velvet.svg
+++ b/public/configs/official/previews/velvet.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/wholespace.svg
+++ b/public/configs/official/previews/wholespace.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/wopian.svg
+++ b/public/configs/official/previews/wopian.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 162.88 A 4,4 0 0 1 726.24,166.88 H 4 A 4,4 0 0 1 0,162.88 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="165.88" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/xtoys.svg
+++ b/public/configs/official/previews/xtoys.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/ys.svg
+++ b/public/configs/official/previews/ys.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/official/previews/zash.svg
+++ b/public/configs/official/previews/zash.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/samples/previews/all-segments.svg
+++ b/public/configs/samples/previews/all-segments.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="951.46" viewBox="0 0 730.24 951.46" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="951.46" viewBox="0 0 730.24 951.46" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 947.46 A 4,4 0 0 1 726.24,951.46 H 4 A 4,4 0 0 1 0,947.46 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="950.46" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/samples/previews/cloud-engineer.svg
+++ b/public/configs/samples/previews/cloud-engineer.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/samples/previews/data-scientist.svg
+++ b/public/configs/samples/previews/data-scientist.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/samples/previews/developer-pro.svg
+++ b/public/configs/samples/previews/developer-pro.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/samples/previews/full-stack.svg
+++ b/public/configs/samples/previews/full-stack.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="193.94" viewBox="0 0 730.24 193.94" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 189.94 A 4,4 0 0 1 726.24,193.94 H 4 A 4,4 0 0 1 0,189.94 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="192.94" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/samples/previews/minimal.svg
+++ b/public/configs/samples/previews/minimal.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="139.83" viewBox="0 0 730.24 139.83" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 135.83 A 4,4 0 0 1 726.24,139.83 H 4 A 4,4 0 0 1 0,135.83 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="138.83" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/public/configs/samples/previews/streamer.svg
+++ b/public/configs/samples/previews/streamer.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px"><style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>
+<svg xmlns="http://www.w3.org/2000/svg" width="730.24" height="166.88" viewBox="0 0 730.24 166.88" font-family="Victor Mono" font-size="16px">
 <path class="omp-window-header" fill="#343434" d="M 4,0 H 726.24 A 4,4 0 0 1 730.24,4 V 26.67 H 0 V 4 A 4,4 0 0 1 4,0 Z"/>
 <path class="omp-window-content" fill="#1e1e1e" d="M 0,26.67 H 730.24 V 162.88 A 4,4 0 0 1 726.24,166.88 H 4 A 4,4 0 0 1 0,162.88 Z"/>
 <rect class="omp-window" x="0.5" y="0.5" width="729.24" height="165.88" rx="4" fill="none" stroke="#404040" stroke-width="1"/>

--- a/scripts/generate-theme-previews.mjs
+++ b/scripts/generate-theme-previews.mjs
@@ -13,8 +13,6 @@ const segmentDataPath = join(projectRoot, 'public', 'studio', 'segment_data.json
 const renderer = process.env.OMP_BIN || 'oh-my-posh';
 const categories = ['samples', 'community'];
 const concurrency = 8;
-const SVG_FONT_STYLE =
-  '<style>@font-face{font-family:"Victor Mono";src:url("/studio/VictorMono.ttf") format("truetype");}</style>';
 
 function previewFileName(filename) {
   return basename(filename).replace(/\.omp\.(json|yaml|yml)$/, '').replace(/\.json$/, '') + '.svg';
@@ -60,7 +58,6 @@ async function renderPreview(configPath, outputPath) {
     );
   }
 
-  await writeFile(outputPath, svg.replace(/^(<svg[^>]*>)/, `$1${SVG_FONT_STYLE}`));
 }
 
 async function mapInBatches(entries, callback) {

--- a/src/components/SamplePicker/ConfigPreview.tsx
+++ b/src/components/SamplePicker/ConfigPreview.tsx
@@ -1,6 +1,5 @@
-import { useState } from 'react';
-import { NerdIcon } from '../NerdIcon';
 import { getConfigPreviewUrl } from '../../utils/configLoader';
+import { GeneratedPreview } from './GeneratedPreview';
 
 interface ConfigPreviewProps {
   category: 'samples' | 'community';
@@ -9,23 +8,7 @@ interface ConfigPreviewProps {
 }
 
 export function ConfigPreview({ category, filename, name }: ConfigPreviewProps) {
-  const [failed, setFailed] = useState(false);
-
-  if (failed) {
-    return (
-      <div className="absolute inset-0 flex items-center justify-center bg-gray-800">
-        <NerdIcon icon="dev-terminal" size={32} className="text-gray-500" />
-      </div>
-    );
-  }
-
   return (
-    <img
-      src={getConfigPreviewUrl(category, filename)}
-      alt={`${name} prompt preview`}
-      loading="lazy"
-      onError={() => setFailed(true)}
-      className="h-full w-full object-contain object-left"
-    />
+    <GeneratedPreview src={getConfigPreviewUrl(category, filename)} label={name} />
   );
 }

--- a/src/components/SamplePicker/GeneratedPreview.tsx
+++ b/src/components/SamplePicker/GeneratedPreview.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+import { NerdIcon } from '../NerdIcon';
+import { sanitizeStudioSvg } from '../../utils/studioSvg';
+
+interface GeneratedPreviewProps {
+  src: string;
+  label: string;
+}
+
+export function GeneratedPreview({ src, label }: GeneratedPreviewProps) {
+  const [svg, setSvg] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    void fetch(src, { signal: controller.signal })
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(`Failed to load preview (${response.status})`);
+        }
+
+        return sanitizeStudioSvg(await response.text());
+      })
+      .then((preview) => setSvg(preview))
+      .catch(() => {
+        if (controller.signal.aborted) return;
+        setFailed(true);
+      });
+
+    return () => controller.abort();
+  }, [src]);
+
+  if (failed) {
+    return (
+      <div className="absolute inset-0 flex items-center justify-center bg-gray-800">
+        <NerdIcon icon="dev-terminal" size={32} className="text-gray-500" />
+      </div>
+    );
+  }
+
+  if (!svg) {
+    return (
+      <div className="absolute inset-0 flex items-center justify-center bg-gray-800">
+        <NerdIcon icon="dev-terminal" size={32} className="animate-pulse text-gray-600" />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="absolute inset-0 flex items-center overflow-hidden bg-gray-900 [&_svg]:h-auto [&_svg]:max-h-full [&_svg]:max-w-full"
+      role="img"
+      aria-label={`${label} prompt preview`}
+      dangerouslySetInnerHTML={{ __html: svg }}
+    />
+  );
+}

--- a/src/components/SamplePicker/OfficialThemeCard.tsx
+++ b/src/components/SamplePicker/OfficialThemeCard.tsx
@@ -1,7 +1,7 @@
 import { NerdIcon } from '../NerdIcon';
 import type { OfficialTheme } from '../../utils/officialThemeLoader';
 import { getThemePreviewUrl } from '../../utils/officialThemeLoader';
-import { useState } from 'react';
+import { GeneratedPreview } from './GeneratedPreview';
 
 interface OfficialThemeCardProps {
   theme: OfficialTheme;
@@ -10,10 +10,7 @@ interface OfficialThemeCardProps {
 }
 
 export function OfficialThemeCard({ theme, onSelect, isLoading }: OfficialThemeCardProps) {
-  const [imageError, setImageError] = useState(false);
-  const [imageLoaded, setImageLoaded] = useState(false);
   const imageUrl = getThemePreviewUrl(theme.file);
-  const hasPreviewImage = Boolean(imageUrl) && !imageError;
 
   return (
     <button
@@ -23,30 +20,7 @@ export function OfficialThemeCard({ theme, onSelect, isLoading }: OfficialThemeC
     >
       {/* Preview Image Container - 16:9 aspect ratio */}
       <div className="relative aspect-video w-full bg-gray-900 overflow-hidden">
-        {hasPreviewImage ? (
-          <>
-            {/* Loading skeleton */}
-            {!imageLoaded && (
-              <div className="absolute inset-0 bg-gray-800 animate-pulse flex items-center justify-center">
-                <NerdIcon icon="dev-terminal" size={32} className="text-gray-600" />
-              </div>
-            )}
-            <img
-              src={imageUrl}
-              alt={`${theme.name} theme preview`}
-              loading="lazy"
-              onLoad={() => setImageLoaded(true)}
-              onError={() => setImageError(true)}
-              className={`w-full h-full object-contain object-left transition-opacity ${
-                imageLoaded ? 'opacity-100' : 'opacity-0'
-              }`}
-            />
-          </>
-        ) : (
-          <div className="absolute inset-0 flex items-center justify-center bg-gray-800">
-            <NerdIcon icon="dev-terminal" size={32} className="text-gray-500" />
-          </div>
-        )}
+        <GeneratedPreview src={imageUrl} label={theme.name} />
         
         {/* Minimal badge */}
         {theme.isMinimal && (


### PR DESCRIPTION
## Summary
- render generated SVG previews inline after sanitization
- inherit the bundled Victor Mono Nerd Font for Powerline and Nerd Font glyphs
- regenerate previews without isolated SVG font rules

## Validation
- npm run lint
- npm run test:run
- npm run build
- npm run validate