### PR TITLE
Refine light-theme dialog surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Oh My Posh Visual Configurator project will be docume
 
 ### Fixed
 
+- Rethemed save, import, share, and code-export flows plus the Advanced Features summary so light mode uses clear, theme-aligned surfaces instead of legacy dark gray fills.
 - Replaced retired official-theme images with server-generated SVG previews for official, sample, and community configurations.
 - Accepted Studio's legacy `#nonce=` fragment alias for secure configuration handoffs while rejecting duplicate or ambiguous nonce parameters.
 

--- a/src/components/AdvancedSettingsDialog/AdvancedSettingsDialog.tsx
+++ b/src/components/AdvancedSettingsDialog/AdvancedSettingsDialog.tsx
@@ -192,7 +192,7 @@ export function AdvancedSettingsDialog({ isOpen, onClose }: AdvancedSettingsDial
         </div>
 
         {/* Master Toggle */}
-        <div className="p-4 border-b border-[#0f3460] bg-[#1a1a2e]/50">
+        <div className="advanced-settings-summary p-4 border-b border-[#0f3460]">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
               <div className="p-2 bg-[#e94560]/20 rounded-lg">

--- a/src/components/ExportBar/ConfigCodePreview.tsx
+++ b/src/components/ExportBar/ConfigCodePreview.tsx
@@ -19,7 +19,7 @@ export function ConfigCodePreview({ content, format }: ConfigCodePreviewProps) {
   const tokens = tokenizeConfig(content, format);
 
   return (
-    <pre className="config-code-preview p-4 text-xs font-mono whitespace-pre-wrap" aria-label={`${format.toUpperCase()} configuration code`}>
+    <pre className="config-code-preview export-code-preview p-4 text-xs font-mono whitespace-pre-wrap" aria-label={`${format.toUpperCase()} configuration code`}>
       {tokens.map((token, index) => (
         <span
           key={`${token.type}-${index}`}

--- a/src/components/ImportDialog/ImportDialog.tsx
+++ b/src/components/ImportDialog/ImportDialog.tsx
@@ -128,7 +128,7 @@ export function ImportDialog({ isOpen, onClose, initialMethod = 'file' }: Import
         </div>
 
         {/* Tabs */}
-        <div className="flex border-b border-gray-700 bg-[#0f0f23] px-6">
+        <div className="dialog-subtle-surface flex border-b border-gray-700 px-6">
           <button
             onClick={() => {
               setActiveMethod('file');
@@ -222,7 +222,7 @@ export function ImportDialog({ isOpen, onClose, initialMethod = 'file' }: Import
                 <label className="block text-sm font-medium text-gray-300 mb-2">
                   Configuration Format
                 </label>
-                <div className="flex items-center gap-2 bg-[#0f0f23] rounded p-0.5">
+                <div className="dialog-input flex items-center gap-2 rounded p-0.5">
                   <button
                     onClick={() => setFormat('json')}
                     className={`px-3 py-1.5 text-sm rounded transition-colors ${
@@ -268,7 +268,7 @@ export function ImportDialog({ isOpen, onClose, initialMethod = 'file' }: Import
                   }}
                   placeholder={`Paste your ${format.toUpperCase()} configuration here...`}
                   rows={12}
-                  className="w-full px-3 py-2 bg-[#0f0f23] border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-purple-500 resize-none font-mono text-sm"
+                  className="dialog-input w-full px-3 py-2 bg-[#0f0f23] border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-purple-500 resize-none font-mono text-sm"
                 />
               </div>
 
@@ -305,7 +305,7 @@ export function ImportDialog({ isOpen, onClose, initialMethod = 'file' }: Import
         </div>
 
         {/* Footer */}
-        <div className="p-4 border-t border-gray-700 bg-[#0f0f23]">
+        <div className="dialog-subtle-surface p-4 border-t border-gray-700">
           <p className="text-xs text-gray-500 text-center">
             Importing will replace your current configuration
           </p>

--- a/src/components/ShareDialog/ShareDialog.tsx
+++ b/src/components/ShareDialog/ShareDialog.tsx
@@ -190,7 +190,7 @@ export function ShareDialog() {
                     value={configName}
                     onChange={(e) => setConfigName(e.target.value)}
                     placeholder="e.g., My Awesome Theme"
-                    className="w-full px-3 py-2 bg-[#0f0f23] border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-purple-500"
+                    className="dialog-input w-full px-3 py-2 bg-[#0f0f23] border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-purple-500"
                   />
                 </div>
 
@@ -203,7 +203,7 @@ export function ShareDialog() {
                     onChange={(e) => setDescription(e.target.value)}
                     placeholder="Brief description of your configuration..."
                     rows={3}
-                    className="w-full px-3 py-2 bg-[#0f0f23] border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-purple-500 resize-none"
+                    className="dialog-input w-full px-3 py-2 bg-[#0f0f23] border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-purple-500 resize-none"
                   />
                 </div>
 
@@ -216,7 +216,7 @@ export function ShareDialog() {
                     value={author}
                     onChange={(e) => setAuthor(e.target.value)}
                     placeholder="e.g., John Doe or @johndoe"
-                    className="w-full px-3 py-2 bg-[#0f0f23] border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-purple-500"
+                    className="dialog-input w-full px-3 py-2 bg-[#0f0f23] border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-purple-500"
                   />
                 </div>
 
@@ -227,7 +227,7 @@ export function ShareDialog() {
                   <button
                     type="button"
                     onClick={() => setIsIconPickerOpen(!isIconPickerOpen)}
-                    className="w-full px-3 py-2 bg-[#0f0f23] border border-gray-700 rounded-lg text-white hover:border-purple-500 focus:outline-none focus:border-purple-500 transition-colors flex items-center justify-between"
+                    className="dialog-input w-full px-3 py-2 bg-[#0f0f23] border border-gray-700 rounded-lg text-white hover:border-purple-500 focus:outline-none focus:border-purple-500 transition-colors flex items-center justify-between"
                   >
                     <div className="flex items-center gap-2">
                       <NerdIcon icon={icon} size={18} />
@@ -236,7 +236,7 @@ export function ShareDialog() {
                     <NerdIcon icon="ui-chevron-down" size={16} className="text-gray-400" />
                   </button>
                   {isIconPickerOpen && (
-                    <div className="absolute z-10 w-full mt-1 bg-[#0f0f23] border border-gray-700 rounded-lg shadow-xl max-h-96 overflow-y-auto">
+                    <div className="dialog-input absolute z-10 w-full mt-1 bg-[#0f0f23] border border-gray-700 rounded-lg shadow-xl max-h-96 overflow-y-auto">
                       <div className="p-3 space-y-4">
                         {Object.entries(iconsByCategory).map(([category, icons]) => (
                           <div key={category}>
@@ -275,7 +275,7 @@ export function ShareDialog() {
                     value={tags}
                     onChange={(e) => setTags(e.target.value)}
                     placeholder="e.g., minimal, developer, colorful"
-                    className="w-full px-3 py-2 bg-[#0f0f23] border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-purple-500"
+                    className="dialog-input w-full px-3 py-2 bg-[#0f0f23] border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-purple-500"
                   />
                 </div>
               </div>
@@ -296,16 +296,16 @@ export function ShareDialog() {
                       repository
                     </a>
                   </li>
-                  <li>Click "Copy Configuration" and create a new file in <code className="bg-gray-900 px-1 py-0.5 rounded text-xs">public/configs/community/your-theme-name.json</code></li>
+                  <li>Click "Copy Configuration" and create a new file in <code className="dialog-inline-code bg-gray-900 px-1 py-0.5 rounded text-xs">public/configs/community/your-theme-name.json</code></li>
                   <li>Paste the configuration into that file</li>
-                  <li>Click "Copy Manifest Entry" and add it to <code className="bg-gray-900 px-1 py-0.5 rounded text-xs">public/configs/community/manifest.json</code></li>
+                  <li>Click "Copy Manifest Entry" and add it to <code className="dialog-inline-code bg-gray-900 px-1 py-0.5 rounded text-xs">public/configs/community/manifest.json</code></li>
                   <li>Submit a pull request with your changes</li>
                 </ol>
               </div>
             </div>
 
             {/* Footer */}
-            <div className="p-6 border-t border-gray-700 bg-[#0f0f23] space-y-4">
+            <div className="dialog-subtle-surface p-6 border-t border-gray-700 space-y-4">
               <a
                 href="https://github.com/jamesmontemagno/ohmyposh-configurator/blob/main/CONTRIBUTING.md"
                 target="_blank"

--- a/src/index.css
+++ b/src/index.css
@@ -37,8 +37,10 @@
   --omp-primary-soft: #ebf2fc;
   --omp-background: #ffffff;
   --omp-surface: #f5f6f7;
+  --omp-surface-hover: #e8eaee;
   --omp-elevated: #ffffff;
   --omp-control: #ebf2fc;
+  --omp-control-hover: #dce9f9;
   --omp-border: #ebedf0;
   --omp-border-strong: #dadde1;
   --omp-text: #1c1e21;
@@ -59,8 +61,10 @@ html[data-theme='dark'] {
   --omp-primary-soft: #1f6ed4;
   --omp-background: #1b1b1d;
   --omp-surface: #242526;
+  --omp-surface-hover: #343638;
   --omp-elevated: #2e2f30;
   --omp-control: #343b48;
+  --omp-control-hover: #404957;
   --omp-border: #444950;
   --omp-border-strong: #606770;
   --omp-text: #f5f6f7;
@@ -145,6 +149,27 @@ body {
   color: var(--omp-text-subtle);
 }
 
+.advanced-settings-summary {
+  background-color: color-mix(in srgb, var(--omp-primary) 8%, var(--omp-elevated));
+}
+
+.dialog-subtle-surface {
+  background-color: var(--omp-surface) !important;
+}
+
+.dialog-input.dialog-input,
+.dialog-inline-code {
+  background-color: var(--omp-control) !important;
+}
+
+.dialog-inline-code {
+  color: var(--omp-text);
+}
+
+.export-code-preview {
+  background-color: var(--omp-elevated);
+}
+
 html[data-theme='dark'] .config-token-key {
   color: #a3cbf7;
 }
@@ -170,12 +195,6 @@ html[data-theme='dark'] .config-token-boolean {
 .theme-library [class~="bg-[#16172e]"],
 .theme-library [class~="hover:bg-[#16172e]"]:hover {
   background-color: var(--omp-elevated) !important;
-}
-
-.theme-library [class~="bg-gray-700"],
-.theme-library [class~="hover:bg-gray-700"]:hover,
-.theme-library [class~="hover:bg-gray-600"]:hover {
-  background-color: var(--omp-control) !important;
 }
 
 .theme-library [class~="border-gray-700"],
@@ -210,6 +229,10 @@ html[data-theme='dark'] .config-token-boolean {
 }
 
 [class~="bg-[#1a1a2e]"] {
+  background-color: var(--omp-elevated) !important;
+}
+
+[class~="bg-[#1a1b2e]"] {
   background-color: var(--omp-elevated) !important;
 }
 
@@ -254,6 +277,34 @@ html[data-theme='dark'] .config-token-boolean {
 
 [class~="hover:bg-[#e94560]/80"]:hover {
   background-color: color-mix(in srgb, var(--omp-primary) 80%, var(--omp-background)) !important;
+}
+
+[class~="bg-gray-800"] {
+  background-color: var(--omp-control) !important;
+}
+
+[class~="bg-gray-700"] {
+  background-color: var(--omp-surface) !important;
+}
+
+[class~="hover:bg-gray-700"]:hover {
+  background-color: var(--omp-surface-hover) !important;
+}
+
+[class~="hover:bg-gray-600"]:hover {
+  background-color: var(--omp-control-hover) !important;
+}
+
+[class~="disabled:bg-gray-700"]:disabled {
+  background-color: var(--omp-surface) !important;
+}
+
+[class~="border-gray-700"] {
+  border-color: var(--omp-border) !important;
+}
+
+[class~="border-gray-600"] {
+  border-color: var(--omp-border-strong) !important;
 }
 
 .peer:checked ~ [class~="peer-checked:bg-[#e94560]"] {


### PR DESCRIPTION
Light mode left legacy dark utility colors in dialog and export flows, making controls and supporting content harder to distinguish.

- Map legacy modal backgrounds, borders, controls, and secondary actions to semantic theme tokens
- Give the Advanced Features summary and export code preview clear, theme-aligned surfaces
- Scope import and share form treatments so the wider workspace palette remains unchanged