### PR TITLE
Fix theme preview regeneration workflow

### DIFF
--- a/.github/workflows/generate-theme-previews.yml
+++ b/.github/workflows/generate-theme-previews.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   generate:
@@ -40,7 +41,10 @@ jobs:
           OMP_BIN: ${{ runner.temp }}/oh-my-posh
         run: node scripts/generate-theme-previews.mjs
 
-      - name: Commit updated previews
+      - name: Create preview update pull request
+        env:
+          BRANCH: automation/theme-preview-${{ github.run_id }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           git add public/configs
           if git diff --cached --quiet; then
@@ -48,5 +52,11 @@ jobs:
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$BRANCH"
           git commit -m "chore: regenerate theme previews"
-          git push
+          git push --set-upstream origin "$BRANCH"
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore: regenerate theme previews" \
+            --body "Automated preview regeneration from $GITHUB_SHA."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Oh My Posh Visual Configurator project will be docume
 
 ### Fixed
 
+- Open a pull request for automated theme-preview updates so protected-branch rules no longer reject regeneration runs.
 - Replaced retired official-theme images with server-generated SVG previews for official, sample, and community configurations.
 - Render generated previews inline so they inherit the bundled Victor Mono Nerd Font and preserve prompt icons.
 - Accepted Studio's legacy `#nonce=` fragment alias for secure configuration handoffs while rejecting duplicate or ambiguous nonce parameters.


### PR DESCRIPTION
Theme-preview regeneration was failing because the workflow tried to push generated files directly to protected `main`.

The workflow now creates a uniquely named automation branch, pushes the generated previews there, and opens a pull request against `main`. It also grants the token permission to create that pull request.