### PR TITLE
feat: add segment context menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Oh My Posh Visual Configurator project will be docume
 
 - Streamlined community theme submissions: the Share dialog now opens a prefilled GitHub issue, and maintainer-approved submissions are validated into draft pull requests automatically.
 - Added one-click MCP server installation links for VS Code, VS Code Insiders, and Visual Studio.
+- Added right-click segment action menus with add, configure, duplicate, documentation, and remove actions where relevant.
 
 ### Fixed
 

--- a/src/components/Canvas/Block.tsx
+++ b/src/components/Canvas/Block.tsx
@@ -34,6 +34,7 @@ export function Block({ block, isSelected, onSelect, onRemove }: BlockProps) {
   const selectSegment = useConfigStore((state) => state.selectSegment);
   const selectedSegmentId = useConfigStore((state) => state.selectedSegmentId);
   const removeSegment = useConfigStore((state) => state.removeSegment);
+  const duplicateSegment = useConfigStore((state) => state.duplicateSegment);
 
   const handleDrop = (e: React.DragEvent) => {
     e.preventDefault();
@@ -140,6 +141,7 @@ export function Block({ block, isSelected, onSelect, onRemove }: BlockProps) {
               isSelected={selectedSegmentId === segment.id}
               onSelect={() => selectSegment(segment.id)}
               onRemove={() => removeSegment(block.id, segment.id)}
+              onDuplicate={() => duplicateSegment(block.id, segment.id)}
             />
           ))
         )}

--- a/src/components/Canvas/Canvas.tsx
+++ b/src/components/Canvas/Canvas.tsx
@@ -232,6 +232,7 @@ export function Canvas() {
               isSelected={false}
               onSelect={() => {}}
               onRemove={() => {}}
+              onDuplicate={() => {}}
               isDragging
             />
           )}

--- a/src/components/Canvas/SegmentCard.tsx
+++ b/src/components/Canvas/SegmentCard.tsx
@@ -1,16 +1,20 @@
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
+import { useState } from 'react';
 import { NerdIcon } from '../NerdIcon';
+import { ContextMenu } from '../ContextMenu';
 import type { Segment } from '../../types/ohmyposh';
 import { useSegmentMetadata } from '../../hooks/useSegmentMetadata';
 import { useConfigStore } from '../../store/configStore';
 import { resolvePaletteColor, getActivePalette } from '../../utils/paletteResolver';
+import { getSegmentDocumentationUrl } from '../../utils/segmentDocumentation';
 
 interface SegmentCardProps {
   segment: Segment;
   isSelected: boolean;
   onSelect: () => void;
   onRemove: () => void;
+  onDuplicate: () => void;
   isDragging?: boolean;
 }
 
@@ -19,8 +23,10 @@ export function SegmentCard({
   isSelected,
   onSelect,
   onRemove,
+  onDuplicate,
   isDragging,
 }: SegmentCardProps) {
+  const [contextMenuPosition, setContextMenuPosition] = useState<{ x: number; y: number } | null>(null);
   const metadata = useSegmentMetadata(segment.type);
   const config = useConfigStore((state) => state.config);
   const previewPaletteName = useConfigStore((state) => state.previewPaletteName);
@@ -34,8 +40,8 @@ export function SegmentCard({
   const foregroundColor = resolvedFg.color || '#ffffff';
 
   const tooltipText = metadata?.name && metadata?.description 
-    ? `${metadata.name}\n\n${metadata.description}` 
-    : metadata?.name || segment.type;
+    ? `${metadata.name}\n\n${metadata.description}\n\nRight-click for actions`
+    : `${metadata?.name || segment.type}\n\nRight-click for actions`;
 
   return (
     <div
@@ -54,6 +60,11 @@ export function SegmentCard({
       onClick={(e) => {
         e.stopPropagation();
         onSelect();
+      }}
+      onContextMenu={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        setContextMenuPosition({ x: event.clientX, y: event.clientY });
       }}
       title={tooltipText}
     >
@@ -74,6 +85,33 @@ export function SegmentCard({
       >
         <NerdIcon icon="ui-close" size={12} />
       </button>
+      {contextMenuPosition && (
+        <ContextMenu
+          position={contextMenuPosition}
+          onClose={() => setContextMenuPosition(null)}
+          items={[
+            { label: 'Configure segment', icon: 'tool-settings', onSelect },
+            { label: 'Duplicate segment', icon: 'action-copy', onSelect: onDuplicate },
+            {
+              label: 'View documentation',
+              icon: 'misc-book',
+              onSelect: () => window.open(
+                getSegmentDocumentationUrl(segment.type, metadata?.category),
+                '_blank',
+                'noopener,noreferrer',
+              ),
+              separatorBefore: true,
+            },
+            {
+              label: 'Remove segment',
+              icon: 'action-trash',
+              onSelect: onRemove,
+              destructive: true,
+              separatorBefore: true,
+            },
+          ]}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/ContextMenu/ContextMenu.tsx
+++ b/src/components/ContextMenu/ContextMenu.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { NerdIcon } from '../NerdIcon';
+
+export interface ContextMenuItem {
+  label: string;
+  icon: string;
+  onSelect: () => void;
+  destructive?: boolean;
+  separatorBefore?: boolean;
+}
+
+interface ContextMenuProps {
+  items: ContextMenuItem[];
+  position: { x: number; y: number };
+  onClose: () => void;
+}
+
+const VIEWPORT_MARGIN = 8;
+
+export function ContextMenu({ items, position, onClose }: ContextMenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [menuPosition, setMenuPosition] = useState(position);
+
+  useLayoutEffect(() => {
+    const menu = menuRef.current;
+    if (!menu) return;
+
+    const { width, height } = menu.getBoundingClientRect();
+    setMenuPosition({
+      x: Math.max(VIEWPORT_MARGIN, Math.min(position.x, window.innerWidth - width - VIEWPORT_MARGIN)),
+      y: Math.max(VIEWPORT_MARGIN, Math.min(position.y, window.innerHeight - height - VIEWPORT_MARGIN)),
+    });
+  }, [position]);
+
+  useEffect(() => {
+    const menu = menuRef.current;
+    menu?.querySelector<HTMLButtonElement>('button:not(:disabled)')?.focus();
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (menu && !menu.contains(event.target as Node)) {
+        onClose();
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    document.addEventListener('pointerdown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('scroll', onClose, true);
+    window.addEventListener('resize', onClose);
+
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('scroll', onClose, true);
+      window.removeEventListener('resize', onClose);
+    };
+  }, [onClose]);
+
+  return createPortal(
+    <div
+      ref={menuRef}
+      role="menu"
+      aria-label="Segment actions"
+      className="fixed z-[100] min-w-48 rounded-md border border-[#0f3460] bg-[#1a1a2e] p-1 shadow-xl"
+      style={{ left: menuPosition.x, top: menuPosition.y }}
+    >
+      {items.map((item) => (
+        <div key={item.label}>
+          {item.separatorBefore && <div className="my-1 border-t border-[#0f3460]" role="separator" />}
+          <button
+            type="button"
+            role="menuitem"
+            className={`flex w-full items-center gap-2 rounded px-2.5 py-1.5 text-left text-sm transition-colors focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-[#e94560] ${
+              item.destructive
+                ? 'text-red-500 hover:bg-red-900/20 hover:text-red-400'
+                : 'text-gray-300 hover:bg-[#0f3460] hover:text-white'
+            }`}
+            onClick={() => {
+              item.onSelect();
+              onClose();
+            }}
+          >
+            <NerdIcon icon={item.icon} size={14} />
+            {item.label}
+          </button>
+        </div>
+      ))}
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/ContextMenu/__tests__/ContextMenu.test.tsx
+++ b/src/components/ContextMenu/__tests__/ContextMenu.test.tsx
@@ -1,0 +1,56 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ContextMenu } from '../ContextMenu';
+
+describe('ContextMenu', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const onClose = vi.fn();
+  const onSelect = vi.fn();
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    onClose.mockReset();
+    onSelect.mockReset();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function renderMenu() {
+    act(() => {
+      root.render(
+        <ContextMenu
+          position={{ x: 16, y: 16 }}
+          onClose={onClose}
+          items={[{ label: 'Duplicate segment', icon: 'action-copy', onSelect }]}
+        />,
+      );
+    });
+  }
+
+  it('runs the selected action and closes the menu', () => {
+    renderMenu();
+
+    const action = document.querySelector<HTMLButtonElement>('[role="menuitem"]');
+    expect(action?.textContent).toContain('Duplicate segment');
+
+    act(() => action?.click());
+
+    expect(onSelect).toHaveBeenCalledOnce();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('closes when Escape is pressed', () => {
+    renderMenu();
+
+    act(() => document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' })));
+
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/ContextMenu/index.ts
+++ b/src/components/ContextMenu/index.ts
@@ -1,0 +1,2 @@
+export { ContextMenu } from './ContextMenu';
+export type { ContextMenuItem } from './ContextMenu';

--- a/src/components/SegmentPicker/SegmentPicker.tsx
+++ b/src/components/SegmentPicker/SegmentPicker.tsx
@@ -1,9 +1,11 @@
 import { useState, useMemo, useEffect } from 'react';
 import { NerdIcon } from '../NerdIcon';
+import { ContextMenu } from '../ContextMenu';
 import { segmentCategories } from '../../data/segments';
 import { loadSegmentCategory, getSegmentCategories } from '../../utils/segmentLoader';
 import type { SegmentMetadata, Segment } from '../../types/ohmyposh';
 import { useConfigStore, generateId } from '../../store/configStore';
+import { getSegmentDocumentationUrl } from '../../utils/segmentDocumentation';
 
 interface SegmentItemProps {
   segment: SegmentMetadata;
@@ -11,35 +13,60 @@ interface SegmentItemProps {
 }
 
 function SegmentItem({ segment, onAdd }: SegmentItemProps) {
+  const [contextMenuPosition, setContextMenuPosition] = useState<{ x: number; y: number } | null>(null);
+  const documentationUrl = getSegmentDocumentationUrl(segment.type, segment.category);
+
   return (
-    <div
-      className="flex items-center gap-1.5 px-1 py-1 hover:bg-[#1a1a2e] rounded cursor-pointer group transition-colors"
-      onClick={() => onAdd(segment)}
-      draggable
-      onDragStart={(e) => {
-        e.dataTransfer.setData('segment-type', segment.type);
-        e.dataTransfer.effectAllowed = 'copy';
-      }}
-      title={`${segment.name}\n\n${segment.description}`}
-    >
-      <NerdIcon icon="ui-grip-vertical" size={12} className="text-gray-500 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0" />
-      <NerdIcon icon={segment.icon} size={16} className="text-gray-400 flex-shrink-0" />
-      <div className="flex-1 min-w-0">
-        <div className="text-[0.95rem] text-gray-200 truncate">{segment.name}</div>
-        {segment.previewText && (
-          <div className="text-[0.8rem] text-gray-500 font-mono truncate">{segment.previewText}</div>
-        )}
-      </div>
-      <button
-        className="text-xs px-1.5 py-0.5 bg-[#0f3460] text-gray-300 rounded opacity-0 group-hover:opacity-100 transition-opacity hover:bg-[#1a4a7a]"
-        onClick={(e) => {
-          e.stopPropagation();
-          onAdd(segment);
+    <>
+      <div
+        className="flex items-center gap-1.5 px-1 py-1 hover:bg-[#1a1a2e] rounded cursor-pointer group transition-colors"
+        onClick={() => onAdd(segment)}
+        onContextMenu={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          setContextMenuPosition({ x: event.clientX, y: event.clientY });
         }}
+        draggable
+        onDragStart={(e) => {
+          e.dataTransfer.setData('segment-type', segment.type);
+          e.dataTransfer.effectAllowed = 'copy';
+        }}
+        title={`${segment.name}\n\n${segment.description}\n\nRight-click for actions`}
       >
-        Add
-      </button>
-    </div>
+        <NerdIcon icon="ui-grip-vertical" size={12} className="text-gray-500 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0" />
+        <NerdIcon icon={segment.icon} size={16} className="text-gray-400 flex-shrink-0" />
+        <div className="flex-1 min-w-0">
+          <div className="text-[0.95rem] text-gray-200 truncate">{segment.name}</div>
+          {segment.previewText && (
+            <div className="text-[0.8rem] text-gray-500 font-mono truncate">{segment.previewText}</div>
+          )}
+        </div>
+        <button
+          className="text-xs px-1.5 py-0.5 bg-[#0f3460] text-gray-300 rounded opacity-0 group-hover:opacity-100 transition-opacity hover:bg-[#1a4a7a]"
+          onClick={(e) => {
+            e.stopPropagation();
+            onAdd(segment);
+          }}
+        >
+          Add
+        </button>
+      </div>
+      {contextMenuPosition && (
+        <ContextMenu
+          position={contextMenuPosition}
+          onClose={() => setContextMenuPosition(null)}
+          items={[
+            { label: 'Add segment', icon: 'ui-plus', onSelect: () => onAdd(segment) },
+            {
+              label: 'View documentation',
+              icon: 'misc-book',
+              onSelect: () => window.open(documentationUrl, '_blank', 'noopener,noreferrer'),
+              separatorBefore: true,
+            },
+          ]}
+        />
+      )}
+    </>
   );
 }
 

--- a/src/utils/__tests__/segmentDocumentation.test.ts
+++ b/src/utils/__tests__/segmentDocumentation.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { getSegmentDocumentationUrl } from '../segmentDocumentation';
+
+describe('getSegmentDocumentationUrl', () => {
+  it('uses the segment category for standard documentation paths', () => {
+    expect(getSegmentDocumentationUrl('git', 'scm')).toBe(
+      'https://ohmyposh.dev/docs/segments/scm/git',
+    );
+  });
+
+  it('falls back to the segment documentation index while metadata loads', () => {
+    expect(getSegmentDocumentationUrl('git')).toBe('https://ohmyposh.dev/docs/segments');
+  });
+
+  it.each([
+    ['copilot_cli', 'cli', 'cli/copilot-cli'],
+    ['gitversion', 'scm', 'cli/gitversion'],
+    ['go', 'languages', 'languages/golang'],
+    ['kubectl', 'cloud', 'cli/kubectl'],
+    ['terraform', 'cloud', 'cli/terraform'],
+    ['winreg', 'web', 'system/winreg'],
+  ] as const)('uses the official path for %s', (type, category, documentationPath) => {
+    expect(getSegmentDocumentationUrl(type, category)).toBe(
+      `https://ohmyposh.dev/docs/segments/${documentationPath}`,
+    );
+  });
+});

--- a/src/utils/segmentDocumentation.ts
+++ b/src/utils/segmentDocumentation.ts
@@ -1,0 +1,28 @@
+import type { SegmentCategory, SegmentType } from '../types/ohmyposh';
+
+const DOCUMENTATION_BASE_URL = 'https://ohmyposh.dev/docs/segments';
+
+const documentationPathOverrides: Partial<Record<SegmentType, string>> = {
+  copilot_cli: 'cli/copilot-cli',
+  gitversion: 'cli/gitversion',
+  go: 'languages/golang',
+  kubectl: 'cli/kubectl',
+  terraform: 'cli/terraform',
+  winreg: 'system/winreg',
+};
+
+/**
+ * Returns the published documentation URL for a configured segment.
+ * A few documentation pages live outside the configurator's display category.
+ */
+export function getSegmentDocumentationUrl(
+  type: SegmentType,
+  category?: SegmentCategory,
+): string {
+  if (!category && !documentationPathOverrides[type]) {
+    return DOCUMENTATION_BASE_URL;
+  }
+
+  const documentationPath = documentationPathOverrides[type] ?? `${category}/${type}`;
+  return `${DOCUMENTATION_BASE_URL}/${documentationPath}`;
+}


### PR DESCRIPTION
Right-clicking a segment previously navigated directly to documentation, which left common editing actions scattered across the workspace. This adds focused context menus so users can act on a segment where they are working.

- Adds a shared, portal-based context menu that stays within the viewport and dismisses on outside click, Escape, scrolling, or resizing.
- Adds picker actions for adding a segment and opening its official documentation.
- Adds canvas actions for configuring, duplicating, opening documentation for, and removing a segment, reusing the existing store operations.
- Resolves official documentation paths, including runtime-type aliases, with focused coverage for routing and menu interaction behavior.