### PR TITLE
feat: enhance MCP catalog and live previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,17 @@ All notable changes to the Oh My Posh Visual Configurator project will be docume
 - Streamlined community theme submissions: the Share dialog now opens a prefilled GitHub issue, and maintainer-approved submissions are validated into draft pull requests automatically.
 - Added one-click MCP server installation links for VS Code, VS Code Insiders, and Visual Studio.
 - Added right-click segment action menus with add, configure, duplicate, documentation, and remove actions where relevant.
+- Added opt-in Oh My Posh CLI detection and local terminal previews to the MCP app while retaining the built-in preview as a fallback.
 
 ### Fixed
 
 - Avoided effect-driven state resets in color selection and saved-configuration editing flows.
+- Updated MCP segment documentation links and inferred prompt generation to cover the complete current segment catalog.
 
 ### Changed: Dependencies
 
 - Updated compatible runtime and development dependencies, including the Model Context Protocol SDK and MCP Apps extension.
+- Added structured outputs and JSON Schemas to machine-readable MCP tools while retaining text responses for older clients.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to the Oh My Posh Visual Configurator project will be docume
 
 ### Fixed
 
+- Required explicit `acknowledgeRisk: true` confirmation before the MCP live-preview tool executes the local Oh My Posh CLI.
 - Avoided effect-driven state resets in color selection and saved-configuration editing flows.
 - Updated MCP segment documentation links and inferred prompt generation to cover the complete current segment catalog.
 

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -251,6 +251,16 @@ Get the official Oh My Posh documentation for a specific segment type from https
 Get official documentation for the git segment
 ```
 
+### get_ohmyposh_cli_status
+
+Check whether the local MCP server can find the `oh-my-posh` executable.
+
+### render_live_preview
+
+Explicitly render a configuration with the locally installed Oh My Posh CLI. The MCP preview app offers this as an opt-in action when the executable is available; otherwise it keeps using the built-in mock renderer.
+
+The CLI runs on the user's machine and evaluates the supplied configuration against that local environment. Use it only for configurations the user intends to render.
+
 ## Available Resources
 
 Resources are read-only data sources that Claude can access:

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -259,7 +259,11 @@ Check whether the local MCP server can find the `oh-my-posh` executable.
 
 Explicitly render a configuration with the locally installed Oh My Posh CLI. The MCP preview app offers this as an opt-in action when the executable is available; otherwise it keeps using the built-in mock renderer.
 
-The CLI runs on the user's machine and evaluates the supplied configuration against that local environment. Use it only for configurations the user intends to render.
+The CLI runs on the user's machine and evaluates the supplied configuration against that local environment. Calls must include `acknowledgeRisk: true`, confirming that the user intends to run the configuration locally.
+
+**Parameters:**
+- `config` (string, required): Configuration to render as a JSON string
+- `acknowledgeRisk` (boolean, required): Must be `true` to permit local CLI execution
 
 ## Available Resources
 

--- a/mcp/apps/preview/src/ansi.test.ts
+++ b/mcp/apps/preview/src/ansi.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { ansiToHtml } from './ansi';
+
+describe('ansiToHtml', () => {
+  it('renders true-color SGR sequences without exposing terminal control codes', () => {
+    expect(ansiToHtml('\u001B[38;2;1;2;3mhello\u001B[0m')).toBe(
+      '<span style="color:rgb(1, 2, 3)">hello</span>'
+    );
+  });
+
+  it('removes OSC hyperlinks and escapes output text', () => {
+    expect(ansiToHtml('\u001B]8;;file:///secret\u001B\\<preview>\u001B]8;;\u001B\\')).toBe(
+      '&lt;preview&gt;'
+    );
+  });
+
+  it('removes unsupported control sequences before rendering output', () => {
+    expect(ansiToHtml('\u001B[2Jpreview')).toBe('preview');
+  });
+});

--- a/mcp/apps/preview/src/ansi.ts
+++ b/mcp/apps/preview/src/ansi.ts
@@ -1,0 +1,130 @@
+interface AnsiStyle {
+  background?: string;
+  bold: boolean;
+  foreground?: string;
+  inverse: boolean;
+}
+
+const ESCAPE = String.fromCharCode(0x1b);
+const BELL = String.fromCharCode(0x07);
+const OSC_SEQUENCE = new RegExp(`${ESCAPE}\\][\\s\\S]*?(?:${BELL}|${ESCAPE}\\\\)`, 'g');
+const CSI_SEQUENCE = new RegExp(`${ESCAPE}\\[([0-?]*[ -/]*)([@-~])`, 'g');
+const SGR_SEQUENCE = new RegExp(`${ESCAPE}\\[([0-9;]*)m`, 'g');
+const SGR_PREFIX = new RegExp(`^${ESCAPE}\\[[0-9;]*m`);
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function sanitizeAnsi(output: string): string {
+  const sanitized = output
+    .replace(OSC_SEQUENCE, '')
+    .replace(CSI_SEQUENCE, (sequence, parameters: string, final: string) => (
+      final === 'm' && /^[0-9;]*$/.test(parameters) ? sequence : ''
+    ));
+  let result = '';
+
+  for (let index = 0; index < sanitized.length; index++) {
+    const character = sanitized[index];
+    const code = character.charCodeAt(0);
+    if (code === 0x1b) {
+      const sgr = sanitized.slice(index).match(SGR_PREFIX);
+      if (sgr) {
+        result += sgr[0];
+        index += sgr[0].length - 1;
+      }
+    } else if (code === 0x09 || code === 0x0a || code === 0x0d || (code >= 0x20 && code !== 0x7f)) {
+      result += character;
+    }
+  }
+
+  return result;
+}
+
+function colorFromSgr(values: number[], index: number): { color?: string; nextIndex: number } {
+  if (values[index + 1] !== 2 || values.length < index + 5) {
+    return { nextIndex: index + 1 };
+  }
+
+  const [red, green, blue] = values.slice(index + 2, index + 5);
+  if ([red, green, blue].some((value) => !Number.isInteger(value) || value < 0 || value > 255)) {
+    return { nextIndex: index + 5 };
+  }
+
+  return { color: `rgb(${red}, ${green}, ${blue})`, nextIndex: index + 5 };
+}
+
+function applySgr(style: AnsiStyle, rawCodes: string): void {
+  const values = rawCodes ? rawCodes.split(';').map(Number) : [0];
+
+  for (let index = 0; index < values.length; index++) {
+    const code = values[index];
+    if (code === 0) {
+      style.background = undefined;
+      style.bold = false;
+      style.foreground = undefined;
+      style.inverse = false;
+    } else if (code === 1) {
+      style.bold = true;
+    } else if (code === 22) {
+      style.bold = false;
+    } else if (code === 7) {
+      style.inverse = true;
+    } else if (code === 27) {
+      style.inverse = false;
+    } else if (code === 38 || code === 48) {
+      const { color, nextIndex } = colorFromSgr(values, index);
+      index = nextIndex - 1;
+      if (color) {
+        if (code === 38) style.foreground = color;
+        else style.background = color;
+      }
+    } else if (code === 39) {
+      style.foreground = undefined;
+    } else if (code === 49) {
+      style.background = undefined;
+    }
+  }
+}
+
+function styleAttribute(style: AnsiStyle): string {
+  const declarations: string[] = [];
+  if (style.foreground) declarations.push(`color:${style.foreground}`);
+  if (style.background) declarations.push(`background-color:${style.background}`);
+  if (style.bold) declarations.push('font-weight:700');
+  if (style.inverse) declarations.push('filter:invert(1)');
+  return declarations.join(';');
+}
+
+export function ansiToHtml(output: string): string {
+  const sanitized = sanitizeAnsi(output);
+  const style: AnsiStyle = { bold: false, inverse: false };
+  let html = '';
+  let cursor = 0;
+  let spanOpen = false;
+
+  for (const match of sanitized.matchAll(SGR_SEQUENCE)) {
+    html += escapeHtml(sanitized.slice(cursor, match.index));
+    if (spanOpen) {
+      html += '</span>';
+      spanOpen = false;
+    }
+
+    applySgr(style, match[1]);
+    const attribute = styleAttribute(style);
+    if (attribute) {
+      html += `<span style="${attribute}">`;
+      spanOpen = true;
+    }
+    cursor = (match.index ?? 0) + match[0].length;
+  }
+
+  html += escapeHtml(sanitized.slice(cursor));
+  if (spanOpen) html += '</span>';
+  return html;
+}

--- a/mcp/apps/preview/src/app.ts
+++ b/mcp/apps/preview/src/app.ts
@@ -5,6 +5,7 @@
 import { App } from '@modelcontextprotocol/ext-apps';
 import { renderConfig, renderConfigInfo } from '../../shared/renderer';
 import { loadNerdFont } from '../../shared/fontLoader';
+import { ansiToHtml } from './ansi';
 import '../../shared/styles.css';
 import './styles.css';
 
@@ -16,6 +17,76 @@ loadNerdFont();
 
 let currentConfig: Record<string, unknown> | null = null;
 let darkMode = true;
+type CliStatus = { available: true; version: string } | { available: false; reason: 'not-found' };
+type LivePreview =
+  | { available: true; version: string; output: string }
+  | { available: false; reason: 'not-found' };
+let cliStatus: CliStatus | 'idle' | 'checking' = 'idle';
+let cliStatusError: string | null = null;
+let livePreview: LivePreview | 'loading' | null = null;
+let livePreviewError: string | null = null;
+let configVersion = 0;
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function parseToolText(result: { content?: Array<{ type: string; text?: string }> }): string | null {
+  const text = result.content?.find((content) => content.type === 'text');
+  return text?.text ?? null;
+}
+
+async function checkCliStatus() {
+  if (cliStatus === 'checking' || typeof cliStatus === 'object') return;
+
+  cliStatus = 'checking';
+  cliStatusError = null;
+  render();
+  try {
+    const result = await app.callServerTool({ name: 'get_ohmyposh_cli_status', arguments: {} });
+    const text = parseToolText(result);
+    cliStatus = text ? JSON.parse(text) as CliStatus : { available: false, reason: 'not-found' };
+  } catch {
+    cliStatus = 'idle';
+    cliStatusError = 'Live preview availability could not be checked.';
+  }
+  render();
+}
+
+async function renderLivePreview() {
+  if (!currentConfig || !('available' in cliStatus) || !cliStatus.available) return;
+
+  const requestedConfigVersion = configVersion;
+  const config = currentConfig;
+  livePreview = 'loading';
+  livePreviewError = null;
+  render();
+  try {
+    const result = await app.callServerTool({
+      name: 'render_live_preview',
+      arguments: { config: JSON.stringify(config) },
+    });
+    const text = parseToolText(result);
+    if (!text) throw new Error('Oh My Posh did not return a preview.');
+    if (requestedConfigVersion !== configVersion) return;
+
+    livePreview = JSON.parse(text) as LivePreview;
+    if (!livePreview.available) {
+      cliStatus = livePreview;
+    }
+  } catch {
+    if (requestedConfigVersion !== configVersion) return;
+
+    livePreview = null;
+    livePreviewError = 'Live preview could not be generated.';
+  }
+  render();
+}
 
 function render() {
   if (!currentConfig) {
@@ -26,6 +97,12 @@ function render() {
   let html = `<div class="preview-header">`;
   html += `<span class="preview-title">Oh My Posh Preview</span>`;
   html += `<div class="preview-actions">`;
+  if (cliStatus === 'checking') {
+    html += `<button class="preview-btn" disabled>Checking CLI...</button>`;
+  } else if (typeof cliStatus === 'object' && cliStatus.available) {
+    const version = escapeHtml(cliStatus.version);
+    html += `<button id="btn-live-preview" class="preview-btn" title="Render using local Oh My Posh ${version}">${livePreview === 'loading' ? 'Rendering...' : 'Live preview'}</button>`;
+  }
   html += `<button id="toggle-bg" class="preview-btn" title="Toggle light/dark terminal background">${darkMode ? '☀️' : '🌙'}</button>`;
   html += `<button id="btn-export-json" class="preview-btn" title="Export as JSON">JSON</button>`;
   html += `<button id="btn-export-yaml" class="preview-btn" title="Export as YAML">YAML</button>`;
@@ -33,6 +110,14 @@ function render() {
   html += `</div></div>`;
 
   html += renderConfig(currentConfig as Parameters<typeof renderConfig>[0], darkMode);
+  if (livePreview && livePreview !== 'loading' && livePreview.available) {
+    const version = escapeHtml(livePreview.version);
+    html += `<div class="live-preview"><div class="live-preview-title">Local Oh My Posh ${version}</div><pre class="live-preview-output">${ansiToHtml(livePreview.output)}</pre></div>`;
+  } else if (livePreviewError) {
+    html += `<div class="live-preview-error">${livePreviewError}</div>`;
+  } else if (cliStatusError) {
+    html += `<div class="live-preview-error">${cliStatusError}</div>`;
+  }
   html += renderConfigInfo(currentConfig as Parameters<typeof renderConfig>[0]);
 
   appEl.innerHTML = html;
@@ -41,6 +126,10 @@ function render() {
   document.getElementById('toggle-bg')?.addEventListener('click', () => {
     darkMode = !darkMode;
     render();
+  });
+
+  document.getElementById('btn-live-preview')?.addEventListener('click', () => {
+    void renderLivePreview();
   });
 
   for (const fmt of ['json', 'yaml', 'toml'] as const) {
@@ -66,10 +155,10 @@ function render() {
 }
 
 function parseConfigFromResult(result: { content?: Array<{ type: string; text?: string }> }) {
-  const textContent = result.content?.find((c) => c.type === 'text');
-  if (textContent && 'text' in textContent && textContent.text) {
+  const text = parseToolText(result);
+  if (text) {
     try {
-      return JSON.parse(textContent.text);
+      return JSON.parse(text);
     } catch {
       return null;
     }
@@ -83,7 +172,11 @@ app.ontoolresult = (result) => {
   if (parsed) {
     // load_sample_config returns { config, metadata } — unwrap if needed
     currentConfig = parsed.config && parsed.config.blocks ? parsed.config : parsed;
+    configVersion += 1;
+    livePreview = null;
+    livePreviewError = null;
     render();
+    void checkCliStatus();
   } else {
     appEl.innerHTML = `<div class="error">Could not parse configuration from tool result</div>`;
   }

--- a/mcp/apps/preview/src/app.ts
+++ b/mcp/apps/preview/src/app.ts
@@ -42,7 +42,7 @@ function parseToolText(result: { content?: Array<{ type: string; text?: string }
 }
 
 async function checkCliStatus() {
-  if (cliStatus === 'checking' || typeof cliStatus === 'object') return;
+  if (cliStatus === 'checking' || (typeof cliStatus === 'object' && cliStatus.available)) return;
 
   cliStatus = 'checking';
   cliStatusError = null;
@@ -59,7 +59,7 @@ async function checkCliStatus() {
 }
 
 async function renderLivePreview() {
-  if (!currentConfig || !('available' in cliStatus) || !cliStatus.available) return;
+  if (!currentConfig || livePreview === 'loading' || !('available' in cliStatus) || !cliStatus.available) return;
 
   const requestedConfigVersion = configVersion;
   const config = currentConfig;
@@ -69,7 +69,7 @@ async function renderLivePreview() {
   try {
     const result = await app.callServerTool({
       name: 'render_live_preview',
-      arguments: { config: JSON.stringify(config) },
+      arguments: { config: JSON.stringify(config), acknowledgeRisk: true },
     });
     const text = parseToolText(result);
     if (!text) throw new Error('Oh My Posh did not return a preview.');
@@ -101,7 +101,7 @@ function render() {
     html += `<button class="preview-btn" disabled>Checking CLI...</button>`;
   } else if (typeof cliStatus === 'object' && cliStatus.available) {
     const version = escapeHtml(cliStatus.version);
-    html += `<button id="btn-live-preview" class="preview-btn" title="Render using local Oh My Posh ${version}">${livePreview === 'loading' ? 'Rendering...' : 'Live preview'}</button>`;
+    html += `<button id="btn-live-preview" class="preview-btn" title="Render using local Oh My Posh ${version}"${livePreview === 'loading' ? ' disabled' : ''}>${livePreview === 'loading' ? 'Rendering...' : 'Live preview'}</button>`;
   }
   html += `<button id="toggle-bg" class="preview-btn" title="Toggle light/dark terminal background">${darkMode ? '☀️' : '🌙'}</button>`;
   html += `<button id="btn-export-json" class="preview-btn" title="Export as JSON">JSON</button>`;

--- a/mcp/apps/preview/src/styles.css
+++ b/mcp/apps/preview/src/styles.css
@@ -36,6 +36,45 @@
   color: #fff;
 }
 
+.preview-btn:disabled {
+  cursor: wait;
+  opacity: 0.65;
+}
+
+.live-preview {
+  margin-top: 12px;
+  border: 1px solid rgba(86, 182, 194, 0.45);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.live-preview-title {
+  padding: 6px 10px;
+  background: rgba(86, 182, 194, 0.12);
+  color: #9ce9f5;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.live-preview-output {
+  margin: 0;
+  padding: 12px;
+  overflow-x: auto;
+  white-space: pre;
+  background: #1a1a2e;
+  font-family: 'NerdSymbols', 'Fira Code', 'Cascadia Code', monospace;
+}
+
+.live-preview-error {
+  margin-top: 12px;
+  padding: 8px 10px;
+  color: #ffb4b4;
+  background: rgba(239, 83, 80, 0.1);
+  border: 1px solid rgba(239, 83, 80, 0.35);
+  border-radius: 6px;
+  font-size: 12px;
+}
+
 @keyframes blink {
   50% { opacity: 0; }
 }

--- a/mcp/index.ts
+++ b/mcp/index.ts
@@ -170,6 +170,10 @@ function jsonToolResult(value: unknown, structuredContent: Record<string, unknow
   };
 }
 
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 // Cache loaded app HTML
 const appHtmlCache = new Map<string, string>();
 async function loadAppHtml(name: string): Promise<string> {
@@ -464,8 +468,14 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               type: 'string',
               description: 'The Oh My Posh configuration to render as a JSON string',
             },
+            acknowledgeRisk: {
+              type: 'boolean',
+              const: true,
+              description:
+                'Must be true to confirm that rendering executes the local Oh My Posh CLI against this configuration.',
+            },
           },
-          required: ['config'],
+          required: ['config', 'acknowledgeRisk'],
         },
         outputSchema: LIVE_PREVIEW_OUTPUT_SCHEMA,
         _meta: { ui: { resourceUri: PREVIEW_RESOURCE_URI }, [RESOURCE_URI_META_KEY]: PREVIEW_RESOURCE_URI },
@@ -620,13 +630,26 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         try {
           config = JSON.parse(configStr);
         } catch (parseError) {
+          const validation = {
+            valid: false,
+            errors: [
+              {
+                path: '$',
+                message: `Invalid JSON: ${getErrorMessage(parseError)}`,
+                severity: 'error' as const,
+              },
+            ],
+            warnings: [],
+          };
+
           return {
             content: [
               {
                 type: 'text',
-                text: 'Error: Invalid JSON\n' + (parseError as Error).message,
+                text: formatValidationResult(validation),
               },
             ],
+            structuredContent: { validation },
             isError: true,
           };
         }
@@ -846,13 +869,45 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'render_live_preview': {
-        const { config: configStr } = args as { config: string };
+        const { config: configStr, acknowledgeRisk } = args as {
+          config: string;
+          acknowledgeRisk?: unknown;
+        };
+        if (acknowledgeRisk !== true) {
+          const reason = 'Live preview execution requires acknowledgeRisk: true.';
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Error: ${reason}`,
+              },
+            ],
+            structuredContent: {
+              available: false,
+              reason,
+            },
+            isError: true,
+          };
+        }
 
         let config: unknown;
         try {
           config = JSON.parse(configStr);
-        } catch {
-          throw new Error('Invalid JSON configuration');
+        } catch (parseError) {
+          const message = getErrorMessage(parseError);
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Error: Invalid JSON\n${message}`,
+              },
+            ],
+            structuredContent: {
+              available: false,
+              reason: `Invalid JSON configuration: ${message}`,
+            },
+            isError: true,
+          };
         }
 
         const result = await renderWithOhMyPosh(config);

--- a/mcp/index.ts
+++ b/mcp/index.ts
@@ -45,6 +45,9 @@ import {
   searchSegments,
   getSegmentCategories,
 } from './lib/segmentLoader.js';
+import { getSegmentDocumentationUrl } from './lib/segmentDocs.js';
+import { inferSegmentsFromDescription } from './lib/segmentInference.js';
+import { getOhMyPoshCliStatus, renderWithOhMyPosh } from './lib/ohMyPoshCli.js';
 import {
   loadConfigById,
   listConfigs,
@@ -67,6 +70,105 @@ const RESOURCE_MIME_TYPE = 'text/html;profile=mcp-app';
 const RESOURCE_URI_META_KEY = 'ui/resourceUri';
 const PREVIEW_RESOURCE_URI = 'ui://ohmyposh-configurator/preview.html';
 const SEGMENTS_RESOURCE_URI = 'ui://ohmyposh-configurator/segments.html';
+
+const CONFIG_OUTPUT_SCHEMA = {
+  type: 'object',
+  properties: {
+    config: { type: 'object' },
+  },
+  required: ['config'],
+};
+
+const VALIDATION_OUTPUT_SCHEMA = {
+  type: 'object',
+  properties: {
+    validation: {
+      type: 'object',
+      properties: {
+        valid: { type: 'boolean' },
+        errors: { type: 'array' },
+        warnings: { type: 'array' },
+      },
+      required: ['valid', 'errors', 'warnings'],
+    },
+  },
+  required: ['validation'],
+};
+
+const EXPORT_OUTPUT_SCHEMA = {
+  type: 'object',
+  properties: {
+    format: { type: 'string', enum: ['json', 'yaml', 'toml'] },
+    output: { type: 'string' },
+  },
+  required: ['format', 'output'],
+};
+
+const SEGMENT_LIST_OUTPUT_SCHEMA = {
+  type: 'object',
+  properties: {
+    segments: { type: 'array', items: { type: 'object' } },
+  },
+  required: ['segments'],
+};
+
+const SEGMENT_OUTPUT_SCHEMA = {
+  type: 'object',
+  properties: {
+    segment: { type: 'object' },
+  },
+  required: ['segment'],
+};
+
+const CONFIG_LIST_OUTPUT_SCHEMA = {
+  type: 'object',
+  properties: {
+    configs: { type: 'array', items: { type: 'object' } },
+  },
+  required: ['configs'],
+};
+
+const SAMPLE_CONFIG_OUTPUT_SCHEMA = {
+  type: 'object',
+  properties: {
+    config: { type: 'object' },
+    metadata: { type: 'object' },
+  },
+  required: ['config', 'metadata'],
+};
+
+const CLI_STATUS_OUTPUT_SCHEMA = {
+  type: 'object',
+  properties: {
+    available: { type: 'boolean' },
+    version: { type: 'string' },
+    reason: { type: 'string' },
+  },
+  required: ['available'],
+};
+
+const LIVE_PREVIEW_OUTPUT_SCHEMA = {
+  type: 'object',
+  properties: {
+    available: { type: 'boolean' },
+    version: { type: 'string' },
+    reason: { type: 'string' },
+    output: { type: 'string' },
+  },
+  required: ['available'],
+};
+
+function jsonToolResult(value: unknown, structuredContent: Record<string, unknown>) {
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(value, null, 2),
+      },
+    ],
+    structuredContent,
+  };
+}
 
 // Cache loaded app HTML
 const appHtmlCache = new Map<string, string>();
@@ -137,6 +239,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           },
           required: ['description'],
         },
+        outputSchema: CONFIG_OUTPUT_SCHEMA,
         _meta: { ui: { resourceUri: PREVIEW_RESOURCE_URI }, [RESOURCE_URI_META_KEY]: PREVIEW_RESOURCE_URI },
       },
       {
@@ -171,6 +274,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           },
           required: ['config', 'segmentType'],
         },
+        outputSchema: CONFIG_OUTPUT_SCHEMA,
       },
       {
         name: 'modify_configuration',
@@ -192,6 +296,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           },
           required: ['config', 'modifications'],
         },
+        outputSchema: CONFIG_OUTPUT_SCHEMA,
         _meta: { ui: { resourceUri: PREVIEW_RESOURCE_URI }, [RESOURCE_URI_META_KEY]: PREVIEW_RESOURCE_URI },
       },
       {
@@ -209,6 +314,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           },
           required: ['config'],
         },
+        outputSchema: VALIDATION_OUTPUT_SCHEMA,
       },
       {
         name: 'export_configuration',
@@ -230,6 +336,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           },
           required: ['config'],
         },
+        outputSchema: EXPORT_OUTPUT_SCHEMA,
       },
       {
         name: 'list_segments',
@@ -250,6 +357,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
           },
         },
+        outputSchema: SEGMENT_LIST_OUTPUT_SCHEMA,
         _meta: { ui: { resourceUri: SEGMENTS_RESOURCE_URI }, [RESOURCE_URI_META_KEY]: SEGMENTS_RESOURCE_URI },
       },
       {
@@ -267,6 +375,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           },
           required: ['segmentType'],
         },
+        outputSchema: SEGMENT_OUTPUT_SCHEMA,
         _meta: { ui: { resourceUri: SEGMENTS_RESOURCE_URI }, [RESOURCE_URI_META_KEY]: SEGMENTS_RESOURCE_URI },
       },
       {
@@ -277,6 +386,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           type: 'object',
           properties: {},
         },
+        outputSchema: CONFIG_LIST_OUTPUT_SCHEMA,
       },
       {
         name: 'load_sample_config',
@@ -292,6 +402,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           },
           required: ['configId'],
         },
+        outputSchema: SAMPLE_CONFIG_OUTPUT_SCHEMA,
         _meta: { ui: { resourceUri: PREVIEW_RESOURCE_URI }, [RESOURCE_URI_META_KEY]: PREVIEW_RESOURCE_URI },
       },
       {
@@ -331,6 +442,34 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           required: ['segmentType'],
         },
       },
+      {
+        name: 'get_ohmyposh_cli_status',
+        description:
+          'Check whether Oh My Posh is installed locally for this MCP server and return its version when available.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+        },
+        outputSchema: CLI_STATUS_OUTPUT_SCHEMA,
+      },
+      {
+        name: 'render_live_preview',
+        description:
+          'Explicitly render an Oh My Posh configuration with the locally installed Oh My Posh CLI. ' +
+          'This evaluates the configuration against the local environment and returns terminal ANSI output for the MCP preview app.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            config: {
+              type: 'string',
+              description: 'The Oh My Posh configuration to render as a JSON string',
+            },
+          },
+          required: ['config'],
+        },
+        outputSchema: LIVE_PREVIEW_OUTPUT_SCHEMA,
+        _meta: { ui: { resourceUri: PREVIEW_RESOURCE_URI }, [RESOURCE_URI_META_KEY]: PREVIEW_RESOURCE_URI },
+      },
     ],
   };
 });
@@ -356,7 +495,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         let config = createDefaultConfig();
 
         // Determine which segments to add based on description and explicit list
-        const segmentsToAdd = segments || inferSegmentsFromDescription(description);
+        const segmentsToAdd = segments || inferSegmentsFromDescription(
+          description,
+          await loadAllSegments(SEGMENTS_DIR)
+        );
         const segmentStyle = style || 'powerline';
 
         // Separate status from main segments for better multi-block layout
@@ -406,14 +548,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           config = addBlockToConfig(config, statusBlock);
         }
 
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(config, null, 2),
-            },
-          ],
-        };
+        return jsonToolResult(config, { config });
       }
 
       case 'add_segment': {
@@ -456,14 +591,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         // Add segment to block
         const updatedConfig = addSegmentToBlock(config, blockIndex, segment);
 
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(updatedConfig, null, 2),
-            },
-          ],
-        };
+        return jsonToolResult(updatedConfig, { config: updatedConfig });
       }
 
       case 'modify_configuration': {
@@ -482,14 +610,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         // Apply modifications
         const updatedConfig = updateGlobalSettings(config, modifications);
 
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(updatedConfig, null, 2),
-            },
-          ],
-        };
+        return jsonToolResult(updatedConfig, { config: updatedConfig });
       }
 
       case 'validate_configuration': {
@@ -506,6 +627,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                 text: 'Error: Invalid JSON\n' + (parseError as Error).message,
               },
             ],
+            isError: true,
           };
         }
 
@@ -517,6 +639,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
               text: formatValidationResult(result),
             },
           ],
+          structuredContent: { validation: result },
         };
       }
 
@@ -542,6 +665,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
               text: output,
             },
           ],
+          structuredContent: { format, output },
         };
       }
 
@@ -581,14 +705,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           description: s.description,
         }));
 
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(summary, null, 2),
-            },
-          ],
-        };
+        return jsonToolResult(summary, { segments: summary });
       }
 
       case 'get_segment_info': {
@@ -599,26 +716,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           throw new Error(`Unknown segment type: ${segmentType}`);
         }
 
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(metadata, null, 2),
-            },
-          ],
-        };
+        return jsonToolResult(metadata, { segment: metadata });
       }
 
       case 'list_sample_configs': {
         const configs = await listConfigs('samples', CONFIGS_DIR);
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(configs, null, 2),
-            },
-          ],
-        };
+        return jsonToolResult(configs, { configs });
       }
 
       case 'load_sample_config': {
@@ -629,14 +732,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           throw new Error(`Sample configuration not found: ${configId}`);
         }
 
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(result, null, 2),
-            },
-          ],
-        };
+        return jsonToolResult(result, result);
       }
 
       case 'search_ohmyposh_docs': {
@@ -687,7 +783,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           throw new Error(`Unknown segment type: ${segmentType}. Use list_segments to see available types.`);
         }
 
-        const docsUrl = `https://ohmyposh.dev/docs/segments/${segmentType.toLowerCase()}`;
+        const docsUrl = getSegmentDocumentationUrl(metadata);
         
         // Build comprehensive response with local metadata and link to official docs
         let response = `# ${metadata.name} Segment\n\n`;
@@ -742,6 +838,25 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             },
           ],
         };
+      }
+
+      case 'get_ohmyposh_cli_status': {
+        const status = await getOhMyPoshCliStatus();
+        return jsonToolResult(status, status);
+      }
+
+      case 'render_live_preview': {
+        const { config: configStr } = args as { config: string };
+
+        let config: unknown;
+        try {
+          config = JSON.parse(configStr);
+        } catch {
+          throw new Error('Invalid JSON configuration');
+        }
+
+        const result = await renderWithOhMyPosh(config);
+        return jsonToolResult(result, result);
       }
 
       default:
@@ -987,58 +1102,6 @@ server.setRequestHandler(GetPromptRequestSchema, async (request) => {
       throw new Error(`Unknown prompt: ${name}`);
   }
 });
-
-/**
- * Helper: Infer segments from natural language description
- */
-function inferSegmentsFromDescription(description: string): string[] {
-  const lower = description.toLowerCase();
-  const segments: string[] = ['path']; // Always include path
-
-  // Version control
-  if (lower.includes('git')) segments.push('git');
-
-  // Languages
-  if (lower.includes('node') || lower.includes('javascript') || lower.includes('npm') || lower.includes('typescript'))
-    segments.push('node');
-  if (lower.includes('python')) segments.push('python');
-  if (lower.includes('go') && !lower.includes('google')) segments.push('go');
-  if (lower.includes('rust')) segments.push('rust');
-  if (lower.includes('java') && !lower.includes('javascript')) segments.push('java');
-  if (lower.includes('dotnet') || lower.includes('.net') || lower.includes('c#') || lower.includes('csharp'))
-    segments.push('dotnet');
-  if (lower.includes('ruby')) segments.push('ruby');
-  if (lower.includes('php')) segments.push('php');
-  if (lower.includes('dart') || lower.includes('flutter')) segments.push('dart');
-  if (lower.includes('swift')) segments.push('swift');
-  if (lower.includes('react')) segments.push('react');
-  if (lower.includes('angular')) segments.push('angular');
-
-  // Cloud
-  if (lower.includes('aws')) segments.push('aws');
-  if (lower.includes('azure')) segments.push('az');
-  if (lower.includes('gcp') || lower.includes('google cloud')) segments.push('gcp');
-  if (lower.includes('kubernetes') || lower.includes('kubectl') || lower.includes('k8s')) segments.push('kubectl');
-  if (lower.includes('docker')) segments.push('docker');
-  if (lower.includes('helm')) segments.push('helm');
-
-  // AI tools
-  if (lower.includes('copilot')) segments.push('copilot');
-
-  // System
-  if (lower.includes('time')) segments.push('time');
-  if (lower.includes('battery')) segments.push('battery');
-  if (lower.includes('shell')) segments.push('shell');
-  if (/\bos\b/.test(lower)) segments.push('os');
-
-  // Dev tools
-  if (lower.includes('terraform')) segments.push('terraform');
-
-  // Always include status at the end
-  segments.push('status');
-
-  return segments;
-}
 
 /**
  * Start the server

--- a/mcp/lib/__tests__/segmentDocs.test.ts
+++ b/mcp/lib/__tests__/segmentDocs.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { getSegmentDocumentationUrl } from '../segmentDocs.js';
+
+describe('getSegmentDocumentationUrl', () => {
+  it('uses the segment category for standard documentation paths', () => {
+    expect(
+      getSegmentDocumentationUrl({ type: 'git', category: 'scm' })
+    ).toBe('https://ohmyposh.dev/docs/segments/scm/git');
+  });
+
+  it('uses an official path override when metadata categories differ', () => {
+    expect(
+      getSegmentDocumentationUrl({ type: 'terraform', category: 'cloud' })
+    ).toBe('https://ohmyposh.dev/docs/segments/cli/terraform');
+  });
+
+  it('uses an official name override when the runtime type differs', () => {
+    expect(
+      getSegmentDocumentationUrl({ type: 'copilot_cli', category: 'cli' })
+    ).toBe('https://ohmyposh.dev/docs/segments/cli/copilot-cli');
+  });
+});

--- a/mcp/lib/__tests__/segmentInference.test.ts
+++ b/mcp/lib/__tests__/segmentInference.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { inferSegmentsFromDescription } from '../segmentInference.js';
+import type { SegmentMetadata } from '../../../src/types/ohmyposh.js';
+
+const segments: SegmentMetadata[] = [
+  { type: 'path', name: 'Path', description: '', category: 'system', icon: '' },
+  { type: 'status', name: 'Status', description: '', category: 'system', icon: '' },
+  { type: 'gradle', name: 'Gradle', description: '', category: 'cli', icon: '' },
+  { type: 'az', name: 'Azure', description: '', category: 'cloud', icon: '' },
+  { type: 'go', name: 'Go', description: '', category: 'languages', icon: '' },
+];
+
+describe('inferSegmentsFromDescription', () => {
+  it('includes a catalog segment outside the old hard-coded keyword list', () => {
+    expect(inferSegmentsFromDescription('Create a Gradle prompt', segments)).toEqual([
+      'path',
+      'gradle',
+      'status',
+    ]);
+  });
+
+  it('matches configured aliases without matching a substring', () => {
+    expect(inferSegmentsFromDescription('An Azure service in Golang', segments)).toEqual([
+      'path',
+      'az',
+      'go',
+      'status',
+    ]);
+    expect(inferSegmentsFromDescription('Configure a prompt', segments)).toEqual([
+      'path',
+      'status',
+    ]);
+  });
+});

--- a/mcp/lib/ohMyPoshCli.ts
+++ b/mcp/lib/ohMyPoshCli.ts
@@ -1,0 +1,76 @@
+import { execFile } from 'node:child_process';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+const COMMAND = 'oh-my-posh';
+const COMMAND_TIMEOUT_MS = 5_000;
+const OUTPUT_BUFFER_BYTES = 1_048_576;
+
+export type OhMyPoshCliStatus =
+  | { available: true; version: string }
+  | { available: false; reason: 'not-found' };
+
+export type OhMyPoshRenderResult =
+  | OhMyPoshCliStatus & { output?: never }
+  | { available: true; version: string; output: string };
+
+function isCommandNotFound(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT';
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function getOhMyPoshCliStatus(): Promise<OhMyPoshCliStatus> {
+  try {
+    const { stdout } = await execFileAsync(COMMAND, ['version'], {
+      timeout: COMMAND_TIMEOUT_MS,
+      maxBuffer: OUTPUT_BUFFER_BYTES,
+      encoding: 'utf8',
+    });
+
+    const version = stdout.trim();
+    if (!version) {
+      throw new Error('Oh My Posh did not return a version.');
+    }
+
+    return { available: true, version };
+  } catch (error) {
+    if (isCommandNotFound(error)) {
+      return { available: false, reason: 'not-found' };
+    }
+
+    throw new Error(`Unable to detect Oh My Posh: ${getErrorMessage(error)}`);
+  }
+}
+
+export async function renderWithOhMyPosh(config: unknown): Promise<OhMyPoshRenderResult> {
+  const status = await getOhMyPoshCliStatus();
+  if (!status.available) return status;
+
+  const directory = await mkdtemp(join(tmpdir(), 'ohmyposh-mcp-'));
+  const configPath = join(directory, 'config.json');
+
+  try {
+    await writeFile(configPath, JSON.stringify(config), 'utf8');
+    const { stdout } = await execFileAsync(
+      COMMAND,
+      ['print', 'primary', '--config', configPath],
+      {
+        timeout: COMMAND_TIMEOUT_MS,
+        maxBuffer: OUTPUT_BUFFER_BYTES,
+        encoding: 'utf8',
+      }
+    );
+
+    return { ...status, output: stdout };
+  } catch (error) {
+    throw new Error(`Unable to render the Oh My Posh preview: ${getErrorMessage(error)}`);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}

--- a/mcp/lib/segmentDocs.ts
+++ b/mcp/lib/segmentDocs.ts
@@ -1,0 +1,18 @@
+import type { SegmentMetadata } from '../../src/types/ohmyposh.js';
+
+const DOCS_BASE_URL = 'https://ohmyposh.dev/docs/segments';
+
+const DOCS_PATH_OVERRIDES: Record<string, string> = {
+  copilot_cli: 'cli/copilot-cli',
+  gitversion: 'cli/gitversion',
+  go: 'languages/golang',
+  kubectl: 'cli/kubectl',
+  terraform: 'cli/terraform',
+  winget: 'system/winget',
+  winreg: 'system/winreg',
+};
+
+export function getSegmentDocumentationUrl(segment: Pick<SegmentMetadata, 'type' | 'category'>): string {
+  const path = DOCS_PATH_OVERRIDES[segment.type] ?? `${segment.category}/${segment.type}`;
+  return `${DOCS_BASE_URL}/${path}`;
+}

--- a/mcp/lib/segmentInference.ts
+++ b/mcp/lib/segmentInference.ts
@@ -1,0 +1,40 @@
+import type { SegmentMetadata } from '../../src/types/ohmyposh.js';
+
+const SEGMENT_ALIASES: Record<string, readonly string[]> = {
+  az: ['azure'],
+  azfunc: ['azure functions'],
+  azd: ['azure developer cli'],
+  dotnet: ['.net', 'c#', 'csharp'],
+  gcp: ['google cloud'],
+  go: ['golang'],
+  kubectl: ['kubernetes', 'k8s'],
+  node: ['javascript', 'typescript'],
+};
+
+function containsTerm(description: string, term: string): boolean {
+  const normalizedTerm = term.trim().toLowerCase();
+  if (normalizedTerm.length < 2) return false;
+
+  const escapedTerm = normalizedTerm.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`(?:^|[^a-z0-9])${escapedTerm}(?=$|[^a-z0-9])`, 'i').test(description);
+}
+
+export function inferSegmentsFromDescription(
+  description: string,
+  availableSegments: readonly SegmentMetadata[]
+): string[] {
+  const inferred = new Set<string>();
+  const availableTypes = new Set(availableSegments.map((segment) => segment.type));
+
+  if (availableTypes.has('path')) inferred.add('path');
+
+  for (const segment of availableSegments) {
+    const terms = [segment.type, segment.name, ...(SEGMENT_ALIASES[segment.type] ?? [])];
+    if (terms.some((term) => containsTerm(description, term))) {
+      inferred.add(segment.type);
+    }
+  }
+
+  if (availableTypes.has('status')) inferred.add('status');
+  return [...inferred];
+}

--- a/src/types/ohmyposh.ts
+++ b/src/types/ohmyposh.ts
@@ -10,6 +10,7 @@ export type BlockAlignment = 'left' | 'right';
 export type SegmentType =
   | 'angular'
   | 'argocd'
+  | 'aspire'
   | 'aurelia'
   | 'aws'
   | 'az'
@@ -46,6 +47,7 @@ export type SegmentType =
   | 'git'
   | 'gitversion'
   | 'go'
+  | 'gradle'
   | 'haskell'
   | 'helm'
   | 'http'
@@ -62,6 +64,7 @@ export type SegmentType =
   | 'mojo'
   | 'mvn'
   | 'nbgv'
+  | 'nba'
   | 'nightscout'
   | 'nim'
   | 'nix-shell'
@@ -82,6 +85,7 @@ export type SegmentType =
   | 'python'
   | 'quasar'
   | 'r'
+  | 'ramadan'
   | 'react'
   | 'root'
   | 'ruby'
@@ -98,10 +102,12 @@ export type SegmentType =
   | 'swift'
   | 'sysinfo'
   | 'talosctl'
+  | 'taskwarrior'
   | 'tauri'
   | 'terraform'
   | 'text'
   | 'time'
+  | 'todoist'
   | 'ui5tooling'
   | 'umbraco'
   | 'uno'
@@ -109,6 +115,7 @@ export type SegmentType =
   | 'upgrade'
   | 'v'
   | 'vala'
+  | 'vimode'
   | 'wakatime'
   | 'winget'
   | 'winreg'
@@ -116,7 +123,8 @@ export type SegmentType =
   | 'xmake'
   | 'yarn'
   | 'ytm'
-  | 'zig';
+  | 'zig'
+  | 'zvm';
 
 export interface Segment {
   id: string; // For drag-and-drop identification


### PR DESCRIPTION
## Summary
- infer prompt segments from the loaded metadata catalog and resolve category-aware official documentation URLs
- add structured MCP tool outputs, JSON schemas, and an explicit invalid-JSON validation error response
- add opt-in local Oh My Posh CLI rendering with safe ANSI preview output

## Validation
- `npm run lint`
- `npm run test:run`
- `npm run build`
- `npm run build:mcp`

Stacked on #93 (`motz-dependency-compatibility`).