### PR TITLE
Publish MCP server to official registry

### DIFF
--- a/.github/workflows/publish-mcp-npm.yml
+++ b/.github/workflows/publish-mcp-npm.yml
@@ -62,3 +62,22 @@ jobs:
         run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create registry manifest
+        run: |
+          jq --arg version "${{ steps.version.outputs.version }}" \
+            '.version = $version | .packages |= map(.version = $version)' \
+            server.json > registry-server.json
+
+      - name: Install MCP Registry publisher
+        run: |
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate with the MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Validate registry manifest
+        run: ./mcp-publisher validate registry-server.json
+
+      - name: Publish to the MCP Registry
+        run: ./mcp-publisher publish registry-server.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Oh My Posh Visual Configurator project will be docume
 
 ### Added
 
+- Added official MCP Registry publishing metadata and GitHub OIDC release automation for the Oh My Posh Configurator MCP server.
 - Added a gated MCP TypeScript SDK v2 migration plan covering the MCP Apps v2 prerequisite, v2 high-level APIs, one-release legacy support, stdio-only transport, VS Code and Copilot CLI acceptance, and a `next` prerelease.
 - Streamlined community theme submissions: the Share dialog now opens a prefilled GitHub issue, and maintainer-approved submissions are validated into draft pull requests automatically.
 - Added one-click MCP server installation links for VS Code, VS Code Insiders, and Visual Studio.

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -30,6 +30,10 @@ Or install globally:
 npm install -g ohmyposh-configurator
 ```
 
+### Official MCP Registry
+
+The server is registered with the [official MCP Registry](https://registry.modelcontextprotocol.io/) as `io.github.jamesmontemagno/ohmyposh-configurator` by the next `mcp-v*` release. Registry metadata and the npm package are published together, so clients discover the same version they install with `npx`.
+
 ### From Source
 
 #### Prerequisites

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "mcpName": "io.github.jamesmontemagno/ohmyposh-configurator",
   "repository": {
     "type": "git",
     "url": "https://github.com/jamesmontemagno/ohmyposh-configurator"

--- a/server.json
+++ b/server.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.jamesmontemagno/ohmyposh-configurator",
+  "title": "Oh My Posh Configurator",
+  "description": "MCP server for creating, validating, and exporting Oh My Posh terminal prompt configurations.",
+  "websiteUrl": "https://configurator.ohmyposh.dev/",
+  "repository": {
+    "url": "https://github.com/jamesmontemagno/ohmyposh-configurator",
+    "source": "github",
+    "subfolder": "mcp"
+  },
+  "version": "1.1.0",
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "ohmyposh-configurator",
+      "version": "1.1.0",
+      "runtimeHint": "npx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Publishing registry metadata alongside the existing npm package lets MCP clients discover the Oh My Posh Configurator server from the official registry while preserving the existing `npx` installation path.

## Summary
- add the npm ownership marker and official `server.json` metadata for `io.github.jamesmontemagno/ohmyposh-configurator`
- publish synchronized registry metadata after npm succeeds on each `mcp-v*` release, using GitHub OIDC with no new secret
- document registry availability and the release behavior

## Notes
- The first registry listing is created by the next MCP release because npm `1.1.0` predates the required `mcpName` marker.
- The workflow generates the manifest version from the resolved release version so npm and registry versions cannot drift.

## Validation
- `mcp-publisher validate` passed for a generated `1.1.1` manifest.
- Project lint, tests, and builds were not run locally because the configured npm proxy returns 404 for the lockfile's `npm@11.19.0` tarball; direct npmjs fallback failed TLS negotiation.